### PR TITLE
refactor: make directory filters responsive with two-column grid layo…

### DIFF
--- a/src/app/directory/page.tsx
+++ b/src/app/directory/page.tsx
@@ -208,7 +208,7 @@ const DirectoryPage = async ({
           <div className=" xl:block xl:w-[20%] shrink-0">
             <Suspense
               fallback={
-                <div className="bg-h_blackLight/50 rounded-xl p-4 h-96 animate-pulse" />
+                <div className="bg-h_blackLight/50 rounded-xl p-4 h-96 animate-pulse " />
               }
             >
               <FilterPanel

--- a/src/components/directory/FilterPanel.tsx
+++ b/src/components/directory/FilterPanel.tsx
@@ -99,128 +99,129 @@ const FilterPanel = ({
   }, []);
 
   return (
-    <div className="bg-h_blackLight/50 rounded-xl p-4 flex flex-col gap-6 sticky top-28">
+    <div className="bg-h_blackLight/50 rounded-xl p-4 flex flex-col gap-4 xl:gap-6 xl:sticky xl:top-28">
       <h3 className="text-h_white font-semibold text-sm">Filters</h3>
-
-      {/* Genre */}
-      <div className="flex flex-col gap-2">
-        <p className="text-gray-400 text-xs font-medium uppercase tracking-wider">
-          Genre
-        </p>
-        <div ref={genreRef} className="relative">
-          <button
-            type="button"
-            onClick={() => setGenreOpen((o) => !o)}
-            className="w-full flex items-center justify-between bg-h_black/50 text-xs rounded-md px-3 py-2 ring-1 ring-gray-700 focus:ring-h_red outline-none"
-          >
-            <span
-              className={
-                selectedGenres.length > 0 ? "text-h_white" : "text-gray-300"
-              }
+      <div className="flex flex-wrap gap-3 xl:flex-colx">
+        {/* Genre */}
+        <div className="flex flex-col gap-2 w-[calc(50%-6px)] xl:w-full">
+          <p className="text-gray-400 text-xs font-medium uppercase tracking-wider">
+            Genre
+          </p>
+          <div ref={genreRef} className="relative  z-50">
+            <button
+              type="button"
+              onClick={() => setGenreOpen((o) => !o)}
+              className="w-full flex items-center justify-between bg-h_black/50 text-xs rounded-md px-3 py-2 ring-1 ring-gray-700 focus:ring-h_red outline-none"
             >
-              {genreLabel}
-            </span>
-            <svg
-              className={`w-3 h-3 text-gray-400 transition-transform ${genreOpen ? "rotate-180" : ""}`}
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M19 9l-7 7-7-7"
-              />
-            </svg>
-          </button>
-
-          {genreOpen && (
-            <div className="absolute z-20 top-full mt-1 w-full bg-h_blackLight border border-gray-700 rounded-md shadow-lg max-h-52 overflow-y-auto">
-              <label className="flex items-center gap-2 px-3 py-2 hover:bg-white/5 cursor-pointer border-b border-gray-800">
-                <input
-                  type="checkbox"
-                  checked={selectedGenres.length === 0}
-                  onChange={() => updateParam("genre", "")}
-                  className="accent-h_red"
+              <span
+                className={
+                  selectedGenres.length > 0 ? "text-h_white" : "text-gray-300"
+                }
+              >
+                {genreLabel}
+              </span>
+              <svg
+                className={`w-3 h-3 text-gray-400 transition-transform ${genreOpen ? "rotate-180" : ""}`}
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M19 9l-7 7-7-7"
                 />
-                <span className="text-gray-300 text-xs">All genres</span>
-              </label>
-              {genres.map((genre) => (
-                <label
-                  key={genre}
-                  className="flex items-center gap-2 px-3 py-2 hover:bg-white/5 cursor-pointer"
-                >
+              </svg>
+            </button>
+
+            {genreOpen && (
+              <div className="absolute z-50 top-full mt-1 w-full bg-h_blackLight border border-gray-700 rounded-md shadow-lg max-h-52 overflow-y-auto">
+                <label className="flex items-center gap-2 px-3 py-2 hover:bg-white/5 cursor-pointer border-b border-gray-800">
                   <input
                     type="checkbox"
-                    checked={selectedGenres.includes(genre)}
-                    onChange={() => toggleGenre(genre)}
+                    checked={selectedGenres.length === 0}
+                    onChange={() => updateParam("genre", "")}
                     className="accent-h_red"
                   />
-                  <span className="text-gray-300 text-xs">{genre}</span>
+                  <span className="text-gray-300 text-xs">All genres</span>
                 </label>
-              ))}
-            </div>
-          )}
+                {genres.map((genre) => (
+                  <label
+                    key={genre}
+                    className="flex items-center gap-2 px-3 py-2 hover:bg-white/5 cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedGenres.includes(genre)}
+                      onChange={() => toggleGenre(genre)}
+                      className="accent-h_red"
+                    />
+                    <span className="text-gray-300 text-xs">{genre}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
-      </div>
 
-      {/* Country */}
-      <div className="flex flex-col gap-2">
-        <p className="text-gray-400 text-xs font-medium uppercase tracking-wider">
-          Country
-        </p>
-        <select
-          value={currentCountry}
-          onChange={(e) => updateCountry(e.target.value)}
-          className="bg-h_black/50 text-gray-300 text-xs rounded-md px-3 py-2 outline-none ring-1 ring-gray-700 focus:ring-h_red"
-        >
-          <option value="">All countries</option>
-          {availableCountries.map((c) => (
-            <option key={c} value={c}>
-              {c}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      {/* City — appears after country is selected */}
-      {currentCountry && citiesForCountry.length > 0 && (
-        <div className="flex flex-col gap-2">
+        {/* Country */}
+        <div className="flex flex-col gap-2 w-[calc(50%-6px)] xl:w-full">
           <p className="text-gray-400 text-xs font-medium uppercase tracking-wider">
-            City
+            Country
           </p>
           <select
-            value={currentCity}
-            onChange={(e) => updateParam("city", e.target.value)}
+            value={currentCountry}
+            onChange={(e) => updateCountry(e.target.value)}
             className="bg-h_black/50 text-gray-300 text-xs rounded-md px-3 py-2 outline-none ring-1 ring-gray-700 focus:ring-h_red"
           >
-            <option value="">All cities</option>
-            {citiesForCountry.map((c) => (
+            <option value="">All countries</option>
+            {availableCountries.map((c) => (
               <option key={c} value={c}>
                 {c}
               </option>
             ))}
           </select>
         </div>
-      )}
 
-      {/* Sort */}
-      <div className="flex flex-col gap-2">
-        <p className="text-gray-400 text-xs font-medium uppercase tracking-wider">
-          Sort By
-        </p>
-        <select
-          value={currentSort}
-          onChange={(e) => updateParam("sort", e.target.value)}
-          className="bg-h_black/50 text-gray-300 text-xs rounded-md px-3 py-2 outline-none ring-1 ring-gray-700 focus:ring-h_red"
-        >
-          {SORT_OPTIONS.map((o) => (
-            <option key={o.value} value={o.value}>
-              {o.label}
-            </option>
-          ))}
-        </select>
+        {/* City — appears after country is selected */}
+        {currentCountry && citiesForCountry.length > 0 && (
+          <div className="flex flex-col gap-2 w-[calc(50%-6px)] xl:w-full">
+            <p className="text-gray-400 text-xs font-medium uppercase tracking-wider">
+              City
+            </p>
+            <select
+              value={currentCity}
+              onChange={(e) => updateParam("city", e.target.value)}
+              className="bg-h_black/50 text-gray-300 text-xs rounded-md px-3 py-2 outline-none ring-1 ring-gray-700 focus:ring-h_red"
+            >
+              <option value="">All cities</option>
+              {citiesForCountry.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {/* Sort */}
+        <div className="flex flex-col gap-2 w-[calc(50%-6px)] xl:w-full">
+          <p className="text-gray-400 text-xs font-medium uppercase tracking-wider">
+            Sort By
+          </p>
+          <select
+            value={currentSort}
+            onChange={(e) => updateParam("sort", e.target.value)}
+            className="bg-h_black/50 text-gray-300 text-xs rounded-md px-3 py-2 outline-none ring-1 ring-gray-700 focus:ring-h_red"
+          >
+            {SORT_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
…ut on mobile

- Change FilterPanel from sticky vertical layout to flex-wrap grid on mobile
- Set filters to two-column layout (50% width each) on small screens, full width on xl
- Adjust gap spacing from `gap-6` to `gap-4 xl:gap-6` for tighter mobile layout
- Make sticky positioning xl-only with `xl:sticky xl:top-28`
- Add z-index to genre dropdown to prevent overlap issues on mobile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the directory filter panel layout for improved responsiveness and better organization of filter options across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->