### PR TITLE
refactor: update demo DJ data with real social links, media content, …

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,6 +30,7 @@ const nextConfig = {
       { protocol: "https", hostname: "theplayground.co.uk" },
       { protocol: "https", hostname: "www.b4l.cz" },
       { protocol: "https", hostname: "www.discoverbenelux.com" },
+      { protocol: "https", hostname: "assets.podomatic.net" },
     ],
   },
   webpack: (config, { isServer }) => {

--- a/src/components/dj-profile/DjProfileFree.tsx
+++ b/src/components/dj-profile/DjProfileFree.tsx
@@ -388,9 +388,9 @@ export default function DjProfileFree({
                 />
               </div>
             </div>
-            <div className="flex-1 min-w-0 pt-1 sm:pb-2">
+            <div className="flex-1 min-w-0 pt-1 sm:pb-2  z-10">
               <h1 className="font-heading text-3xl md:text-4xl text-white leading-none">
-                {DJ.stageName}
+                Dj {DJ.stageName}
               </h1>
               <p className="text-gray-400 text-sm mt-1.5 flex items-center gap-1.5">
                 <FontAwesomeIcon

--- a/src/components/dj-profile/DjProfilePremium.tsx
+++ b/src/components/dj-profile/DjProfilePremium.tsx
@@ -751,8 +751,8 @@ export default function DjProfilePremium({
 
             <div className="flex-1 min-w-0 pt-1 sm:pb-2">
               <div className="flex flex-wrap items-center gap-2 mb-1.5">
-                <h1 className="font-heading text-3xl md:text-4xl text-white leading-none">
-                  {DJ.stageName}
+                <h1 className="font-heading text-3xl md:text-4xl text-white leading-none z-10">
+                  Dj {DJ.stageName}
                 </h1>
                 <div className="flex items-center gap-1.5">
                   <Badge className="bg-blue-500/15 text-blue-400 border-blue-500/25 text-xs h-5.5">

--- a/src/data/djscovery_seed_1.json
+++ b/src/data/djscovery_seed_1.json
@@ -13,20 +13,18 @@
       "country": "Nigeria"
     },
     "avatar": {
-      "url": "https://i.kfs.io/album/global/290973828,0v1/fit/500x500.jpg",
+      "url": "https://assets.podomatic.net/ts/c1/e5/27/djamara22/600x600_12651194.jpg",
       "alt": "Amara Pulse"
     },
     "coverImage": {
       "url": "https://images.unsplash.com/photo-1501386761578-eac5c94b800a",
       "alt": "Amara Pulse live performance cover"
     },
-    "genres": ["Afrobeats", "Amapiano", "House", "Afro-Tech"],
+    "genres": ["R&B", "Electro House", "Hip-Hop"],
     "socials": {
-      "instagram": "https://www.instagram.com/amara.musicc/",
-      "soundcloud": "https://soundcloud.com/felipe-clavero/pulse-original-mix-amara",
-      "spotify": "https://open.spotify.com/album/24cH1e7Qvhsr6XvHMlo3Wi",
-      "youtube": "https://www.youtube.com/channel/UCCFyNdZfRJAOx1E3qgIkVzg",
-      "anghami": "https://play.anghami.com/song/1264441505",
+      "instagram": "https://www.instagram.com/djamara/?hl=en",
+      "soundcloud": "https://soundcloud.com/djamara",
+      "youtube": "https://www.youtube.com/channel/UCERf4bNH_7SzQA-wUFqa7pw",
       "website": "https://www.djamara.com/bio"
     },
     "stats": {
@@ -40,20 +38,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "Afrobeats Sessions Vol.5",
+        "title": "Miguel - Do You (Ark Patrol Remix)",
         "duration": "80m",
         "plays": 51339,
-        "genres": ["Afrobeats", "Amapiano"],
-        "audioUrl": "https://soundcloud.com/amara-pulse/afrobeats-sessions",
+        "genres": ["R&B", "Electro House"],
+        "audioUrl": "https://soundcloud.com/djamara/sets/tora-jaigantic-galimatias?si=c4ce5464119c41e39dd6e567772a0573&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1514525253161-7a46d19cd819"
       },
       "featuredVideo": {
-        "title": "Live @ Fabric London 2025",
+        "title": "Skybound (DJ Amara - The 11th Hour – Track 9)",
         "subtitle": "Full headline set recording",
         "duration": "64 min",
         "views": 340029,
         "thumbnail": "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/jKgfYtkSs0U?si=R8NvCr1ERBF0c0fO"
       }
     },
     "analytics": {
@@ -384,16 +382,16 @@
         "duration": "76m",
         "plays": 147492,
         "genres": ["Hip-Hop", "R&B"],
-        "audioUrl": "https://soundcloud.com/marcus-groove/hip-hop-sessions",
+        "audioUrl": "https://soundcloud.com/reagancooper97/mc-marcus-dj-topgroove?si=c01bb58d1d0a4478b3112d8e62cbf59e&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3"
       },
       "featuredVideo": {
-        "title": "Live @ Pacha 2025",
+        "title": "DJ Marcus Intro",
         "subtitle": "Full headline set recording",
         "duration": "46 min",
         "views": 360835,
         "thumbnail": "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/PgXxxq3fLm4"
       }
     },
     "analytics": {
@@ -682,7 +680,7 @@
     ]
   },
   {
-    "id": "dj_dj_nova",
+    "id": "dj_nova",
     "slug": "dj-nova",
     "type": "fictional_demo",
     "plan": "premium",
@@ -723,20 +721,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "House Sessions Vol.8",
+        "title": "REGGAETON CLASSICO VOL.1",
         "duration": "86m",
         "plays": 28773,
         "genres": ["House", "Techno"],
-        "audioUrl": "https://soundcloud.com/dj-nova/house-sessions",
+        "audioUrl": "https://soundcloud.com/djnovanyc/reggaeton-classico-vol-1?si=88c23e0241d64a94a720841ca3173951&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f"
       },
       "featuredVideo": {
-        "title": "Live @ Club Space 2025",
+        "title": "DJ NOVA – THE ALBUM (Afro-House Feat. Eurodance 90s Vibes) | THE ULTIMATE SUMMER 2025 MEGAMIX",
         "subtitle": "Full headline set recording",
         "duration": "38 min",
         "views": 132854,
         "thumbnail": "https://images.unsplash.com/photo-1506157786151-b8491531f063",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/S3AXrm56QMQ?si=cgBddUWkxPefZUAn"
       }
     },
     "analytics": {
@@ -1399,11 +1397,11 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "Organic House Sessions Vol.3",
+        "title": "Human + Spirit",
         "duration": "83m",
         "plays": 144936,
         "genres": ["Organic House", "Melodic Techno"],
-        "audioUrl": "https://soundcloud.com/ayla-moon/organic-house-sessions",
+        "audioUrl": "https://soundcloud.com/dj-ayla-402039174/human-spirit?si=94392ea586fd4c55acabca1a7d2e7160&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1492684223066-81342ee5ff30"
       },
       "featuredVideo": {
@@ -1739,20 +1737,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "EDM Sessions Vol.2",
+        "title": "Martin Garrix & Ed Sheeran",
         "duration": "89m",
         "plays": 167264,
         "genres": ["EDM", "Progressive House"],
-        "audioUrl": "https://soundcloud.com/martin-garrix/edm-sessions",
+        "audioUrl": "https://soundcloud.com/martingarrix/repeat-it?si=cb853356a1a14608b4cb8f7e9257cc75&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1501386761578-eac5c94b800a"
       },
       "featuredVideo": {
-        "title": "Live @ Berns 2025",
+        "title": "Martin Garrix & Ed Sheeran - Repeat It (Official Video)",
         "subtitle": "Full headline set recording",
         "duration": "59 min",
         "views": 319575,
         "thumbnail": "https://images.unsplash.com/photo-1514525253161-7a46d19cd819",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://www.youtube.com/watch?v=Sf9NZF5qBak"
       }
     },
     "analytics": {
@@ -2080,15 +2078,15 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "House Sessions Vol.2",
+        "title": "EoO - Bad Bunny (Peggy Gou Rhythm Mix)",
         "duration": "78m",
         "plays": 44891,
         "genres": ["House", "Techno"],
-        "audioUrl": "https://soundcloud.com/peggy-gou/house-sessions",
+        "audioUrl": "https://soundcloud.com/peggygou/eoo-bad-bunny-peggy-gou-rhythm?si=6101631109bc46168c020488e5e3f1f9&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1514525253161-7a46d19cd819"
       },
       "featuredVideo": {
-        "title": "Live @ DC-10 2025",
+        "title": "Peggy Gou - Starry Night",
         "subtitle": "Full headline set recording",
         "duration": "59 min",
         "views": 349962,
@@ -2405,6 +2403,7 @@
     "genres": ["Afro House", "Deep House", "House"],
     "socials": {
       "instagram": "https://www.instagram.com/realblackcoffee/?hl=en",
+      "soundcloud": "https://soundcloud.com/realblackcoffee",
       "spotify": "https://open.spotify.com/artist/6wMr4zKPrrR0UVz08WtUWc",
       "youtube": "https://www.youtube.com/channel/UC0cUnMCsopLMon3_lXYTx_g",
       "website": "https://www.realblackcoffee.net/music"
@@ -2420,20 +2419,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "Afro House Sessions Vol.5",
+        "title": "Billie Eilish - CHIHIRO (Black Coffee Remix)",
         "duration": "88m",
         "plays": 153128,
         "genres": ["Afro House", "Deep House"],
-        "audioUrl": "https://soundcloud.com/black-coffee/afro-house-sessions",
+        "audioUrl": "https://soundcloud.com/realblackcoffee/billie-eilish-chihiro-black-coffee-remix?si=3bc48e0f57ef498db31fb7a88dd93856&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3"
       },
       "featuredVideo": {
-        "title": "Live @ Rex Club 2025",
+        "title": "Mayan Warrior - Burning Man 2025",
         "subtitle": "Full headline set recording",
         "duration": "71 min",
         "views": 250402,
         "thumbnail": "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://www.youtube.com/watch?v=FH7lIOv1s3Q"
       }
     },
     "analytics": {
@@ -2762,20 +2761,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "Techno Sessions Vol.2",
+        "title": "Charlotte de Witte - The Realm (Original Mix)",
         "duration": "70m",
         "plays": 145754,
         "genres": ["Techno", "Acid Techno"],
-        "audioUrl": "https://soundcloud.com/charlotte-de-witte/techno-sessions",
+        "audioUrl": "https://soundcloud.com/charlottedewittemusic/charlotte-de-witte-the-realm-original-mix-1?in=charlottedewittemusic/sets/charlotte-de-witte&si=6b64934a37224caea71764f3be34595f&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f"
       },
       "featuredVideo": {
-        "title": "Live @ Berghain 2025",
+        "title": "Charlotte de Witte feat. CERES - Amor (Original Mix) [KNTXT033]",
         "subtitle": "Full headline set recording",
         "duration": "55 min",
         "views": 136249,
         "thumbnail": "https://images.unsplash.com/photo-1506157786151-b8491531f063",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/R9m5i-A749I?si=fW89zDoMpUQF2jky"
       }
     },
     "analytics": {
@@ -3104,20 +3103,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "EDM Sessions Vol.3",
+        "title": "Selfish Love",
         "duration": "53m",
         "plays": 166265,
         "genres": ["EDM", "Trap"],
-        "audioUrl": "https://soundcloud.com/dj-snake/edm-sessions",
+        "audioUrl": "https://soundcloud.com/djsnake/selfish-love?si=e06c83a877ca41d99d3f123e4ee70d44&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1506157786151-b8491531f063"
       },
       "featuredVideo": {
-        "title": "Live @ Fabric London 2025",
+        "title": "DJ Snake - Cairo Express",
         "subtitle": "Full headline set recording",
         "duration": "64 min",
         "views": 307665,
         "thumbnail": "https://images.unsplash.com/photo-1492684223066-81342ee5ff30",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/uy-58A5midE?si=gOIxHB8Le5UUep2O"
       }
     },
     "analytics": {
@@ -3444,20 +3443,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "Techno Sessions Vol.2",
+        "title": "I'm Black and I'm Proud - Say It Loud (Carl Cox Remix)",
         "duration": "65m",
         "plays": 96873,
         "genres": ["Techno", "House"],
-        "audioUrl": "https://soundcloud.com/carl-cox/techno-sessions",
+        "audioUrl": "https://soundcloud.com/carl-cox/sets/im-black-and-im-proud-say-it?si=eb24f3e3461144e3aca180010509ffeb&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1492684223066-81342ee5ff30"
       },
       "featuredVideo": {
-        "title": "Live @ Pacha 2025",
+        "title": "Carl Cox & Perry Farrell - Joya (Radio Edit)",
         "subtitle": "Full headline set recording",
         "duration": "54 min",
         "views": 290508,
         "thumbnail": "https://images.unsplash.com/photo-1501386761578-eac5c94b800a",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/yxPwqPKYx_8?si=FKsD_j7_FCIMRR1h"
       }
     },
     "analytics": {
@@ -3784,20 +3783,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "Techno Sessions Vol.3",
+        "title": "Amelie Lens - our frequency",
         "duration": "80m",
         "plays": 134929,
         "genres": ["Techno", "Minimal Techno"],
-        "audioUrl": "https://soundcloud.com/amelie-lens/techno-sessions",
+        "audioUrl": "https://soundcloud.com/amelielens/amelie-lens-our-frequency?si=fb724de7836c4b0bb0e59b004ad08c2e&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1501386761578-eac5c94b800a"
       },
       "featuredVideo": {
-        "title": "Live @ Club Space 2025",
+        "title": "Amelie Lens - our frequency",
         "subtitle": "Full headline set recording",
         "duration": "61 min",
         "views": 126381,
         "thumbnail": "https://images.unsplash.com/photo-1514525253161-7a46d19cd819",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/nPWxLBT8oj4?si=6FieQhtSakVZNGKB"
       }
     },
     "analytics": {
@@ -4124,20 +4123,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "Tech House Sessions Vol.2",
+        "title": "FISHER x Tones And I - Favour",
         "duration": "79m",
         "plays": 22021,
         "genres": ["Tech House", "House"],
-        "audioUrl": "https://soundcloud.com/fisher/tech-house-sessions",
+        "audioUrl": "https://soundcloud.com/fish-tales/fisher-x-tones-i-favour?si=daf4a65f50d749fd840dc9deefcf9486&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1514525253161-7a46d19cd819"
       },
       "featuredVideo": {
-        "title": "Live @ Printworks 2025",
+        "title": "FISHER & Tones and I - FAVOUR [Official Music Video]",
         "subtitle": "Full headline set recording",
         "duration": "46 min",
         "views": 228977,
         "thumbnail": "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/B7i3D8E8kOw?si=GReUrw2p5y5qwjRp"
       }
     },
     "analytics": {
@@ -4467,20 +4466,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "EDM Sessions Vol.2",
+        "title": "Selected by Steve Aoki",
         "duration": "86m",
         "plays": 166315,
         "genres": ["EDM", "Electro House"],
-        "audioUrl": "https://soundcloud.com/steve-aoki/edm-sessions",
+        "audioUrl": "https://soundcloud.com/steveaoki/sets/soundcloud-aapi?si=181c621c6d2b4d00a354c6540421e6d8&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3"
       },
       "featuredVideo": {
-        "title": "Live @ Shelter NYC 2025",
+        "title": "Farruko, Greeicy, Steve Aoki - YAPAQUE (Official Video)",
         "subtitle": "Full headline set recording",
         "duration": "48 min",
         "views": 172803,
         "thumbnail": "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/dZzBa7jlXY0?si=QSiVGfEb0HTDysCz"
       }
     },
     "analytics": {
@@ -4808,20 +4807,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "Deep House Sessions Vol.8",
+        "title": "Live It All",
         "duration": "55m",
         "plays": 54659,
         "genres": ["Deep House", "Tropical House"],
-        "audioUrl": "https://soundcloud.com/lost-frequencies/deep-house-sessions",
+        "audioUrl": "https://soundcloud.com/lo-freq-1/live-it-all?si=caf76376caf04cd686643eb0abb8e7d6&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f"
       },
       "featuredVideo": {
-        "title": "Live @ Berns 2025",
+        "title": "Tomorrowland Winter 2026",
         "subtitle": "Full headline set recording",
         "duration": "64 min",
         "views": 365777,
         "thumbnail": "https://images.unsplash.com/photo-1506157786151-b8491531f063",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/Nlmh1ASVPYs?si=r10MjoY99mbx5MEw"
       }
     },
     "analytics": {

--- a/src/data/djscovery_seed_1.json
+++ b/src/data/djscovery_seed_1.json
@@ -730,7 +730,7 @@
       },
       "featuredVideo": {
         "title": "DJ NOVA – THE ALBUM (Afro-House Feat. Eurodance 90s Vibes) | THE ULTIMATE SUMMER 2025 MEGAMIX",
-        "subtitle": "Full headline set recording",
+        "subtitle": "Live festival Performance",
         "duration": "38 min",
         "views": 132854,
         "thumbnail": "https://images.unsplash.com/photo-1506157786151-b8491531f063",
@@ -1067,7 +1067,7 @@
       },
       "featuredVideo": {
         "title": "Live @ Printworks 2025",
-        "subtitle": "Full headline set recording",
+        "subtitle": "Live festival Performance",
         "duration": "59 min",
         "views": 392111,
         "thumbnail": "https://images.unsplash.com/photo-1492684223066-81342ee5ff30",
@@ -1406,7 +1406,7 @@
       },
       "featuredVideo": {
         "title": "Live @ Shelter NYC 2025",
-        "subtitle": "Full headline set recording",
+        "subtitle": "Live festival Performance",
         "duration": "52 min",
         "views": 143997,
         "thumbnail": "https://images.unsplash.com/photo-1501386761578-eac5c94b800a",
@@ -1745,8 +1745,8 @@
         "coverImage": "https://images.unsplash.com/photo-1501386761578-eac5c94b800a"
       },
       "featuredVideo": {
-        "title": "Martin Garrix & Ed Sheeran - Repeat It (Official Video)",
-        "subtitle": "Full headline set recording",
+        "title": "Martin Garrix & Ed Sheeran - Repeat It",
+        "subtitle": "Official Music Video",
         "duration": "59 min",
         "views": 319575,
         "thumbnail": "https://images.unsplash.com/photo-1514525253161-7a46d19cd819",
@@ -2428,7 +2428,7 @@
       },
       "featuredVideo": {
         "title": "Mayan Warrior - Burning Man 2025",
-        "subtitle": "Full headline set recording",
+        "subtitle": "Live festival Performance",
         "duration": "71 min",
         "views": 250402,
         "thumbnail": "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f",
@@ -3112,7 +3112,7 @@
       },
       "featuredVideo": {
         "title": "DJ Snake - Cairo Express",
-        "subtitle": "Full headline set recording",
+        "subtitle": "Official Music Video",
         "duration": "64 min",
         "views": 307665,
         "thumbnail": "https://images.unsplash.com/photo-1492684223066-81342ee5ff30",
@@ -3792,7 +3792,7 @@
       },
       "featuredVideo": {
         "title": "Amelie Lens - our frequency",
-        "subtitle": "Full headline set recording",
+        "subtitle": "Official Music Video",
         "duration": "61 min",
         "views": 126381,
         "thumbnail": "https://images.unsplash.com/photo-1514525253161-7a46d19cd819",
@@ -4131,8 +4131,8 @@
         "coverImage": "https://images.unsplash.com/photo-1514525253161-7a46d19cd819"
       },
       "featuredVideo": {
-        "title": "FISHER & Tones and I - FAVOUR [Official Music Video]",
-        "subtitle": "Full headline set recording",
+        "title": "FISHER & Tones and I - FAVOUR",
+        "subtitle": "Official Music Video",
         "duration": "46 min",
         "views": 228977,
         "thumbnail": "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3",
@@ -4474,8 +4474,8 @@
         "coverImage": "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3"
       },
       "featuredVideo": {
-        "title": "Farruko, Greeicy, Steve Aoki - YAPAQUE (Official Video)",
-        "subtitle": "Full headline set recording",
+        "title": "Farruko, Greeicy, Steve Aoki - YAPAQUE",
+        "subtitle": "Official Music Video",
         "duration": "48 min",
         "views": 172803,
         "thumbnail": "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f",
@@ -4816,7 +4816,7 @@
       },
       "featuredVideo": {
         "title": "Tomorrowland Winter 2026",
-        "subtitle": "Full headline set recording",
+        "subtitle": "Live festival Performance",
         "duration": "64 min",
         "views": 365777,
         "thumbnail": "https://images.unsplash.com/photo-1506157786151-b8491531f063",

--- a/src/data/djscovery_seed_2.json
+++ b/src/data/djscovery_seed_2.json
@@ -48,7 +48,7 @@
       },
       "featuredVideo": {
         "title": "Why I Still Miss You",
-        "subtitle": "Full headline set recording",
+        "subtitle": "Official music video",
         "duration": "43 min",
         "views": 105000,
         "thumbnail": "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f",
@@ -386,7 +386,7 @@
       },
       "featuredVideo": {
         "title": "Live @ Pacha 2025",
-        "subtitle": "Full headline set recording",
+        "subtitle": "Live Festival Performance",
         "duration": "44 min",
         "views": 132000,
         "thumbnail": "https://images.unsplash.com/photo-1506157786151-b8491531f063",
@@ -723,8 +723,8 @@
         "coverImage": "https://images.unsplash.com/photo-1506157786151-b8491531f063"
       },
       "featuredVideo": {
-        "title": "Late Night Mirage 2026 | Arabic EDM × Balkan Chill Progressive Mix 🌙",
-        "subtitle": "Full headline set recording",
+        "title": "Late Night Mirage 2026",
+        "subtitle": "Arabic EDM × Balkan Chill Progressive Mix 🌙",
         "duration": "45 min",
         "views": 159000,
         "thumbnail": "https://images.unsplash.com/photo-1492684223066-81342ee5ff30",
@@ -1062,8 +1062,8 @@
         "coverImage": "https://images.unsplash.com/photo-1492684223066-81342ee5ff30"
       },
       "featuredVideo": {
-        "title": "Live @ Printworks 2025",
-        "subtitle": "Full headline set recording",
+        "title": "Printworks 2025",
+        "subtitle": "Live Festival Performance",
         "duration": "46 min",
         "views": 186000,
         "thumbnail": "https://images.unsplash.com/photo-1516450360452-9312f5e86fc7",
@@ -1403,7 +1403,7 @@
       },
       "featuredVideo": {
         "title": "Cubano House 🔥 Afro Latin Club Groove",
-        "subtitle": "Full headline set recording",
+        "subtitle": "Live Festival Performance",
         "duration": "47 min",
         "views": 213000,
         "thumbnail": "https://images.unsplash.com/photo-1540039155733-5bb30b53aa14",
@@ -1743,8 +1743,8 @@
         "coverImage": "https://images.unsplash.com/photo-1540039155733-5bb30b53aa14"
       },
       "featuredVideo": {
-        "title": "Armin van Buuren & Olive Anguz - Vem Comigo (Official Music Video)",
-        "subtitle": "Full headline set recording",
+        "title": "Armin van Buuren & Olive Anguz - Vem Comigo",
+        "subtitle": "Official Music Video",
         "duration": "48 min",
         "views": 240000,
         "thumbnail": "https://images.unsplash.com/photo-1501386761578-eac5c94b800a",
@@ -2084,8 +2084,8 @@
         "coverImage": "https://images.unsplash.com/photo-1501386761578-eac5c94b800a"
       },
       "featuredVideo": {
-        "title": "Tiësto Live at EDC Las Vegas 2026",
-        "subtitle": "Full headline set recording",
+        "title": "EDC Las Vegas 2026",
+        "subtitle": "Live Festival Performance",
         "duration": "49 min",
         "views": 267000,
         "thumbnail": "https://images.unsplash.com/photo-1514525253161-7a46d19cd819",
@@ -2424,8 +2424,8 @@
         "coverImage": "https://images.unsplash.com/photo-1514525253161-7a46d19cd819"
       },
       "featuredVideo": {
-        "title": "David Guetta & Hypaton - Walked Away (Live Performance @ Tomorrowland 2025)",
-        "subtitle": "Full headline set recording",
+        "title": "David Guetta & Hypaton - Walked Away @ Tomorrowland 2025",
+        "subtitle": "Live Festival Performance",
         "duration": "50 min",
         "views": 294000,
         "thumbnail": "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3",
@@ -2766,7 +2766,7 @@
       },
       "featuredVideo": {
         "title": "Alok b2b Green Velvet @ EDC Orlando 2025",
-        "subtitle": "Full headline set recording",
+        "subtitle": "Live Festival Performance",
         "duration": "51 min",
         "views": 321000,
         "thumbnail": "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f",
@@ -3106,7 +3106,7 @@
       },
       "featuredVideo": {
         "title": "Don Diablo, Wiz Khalifa & Chri$tian Gate$ - Go Home With A Stranger [LA SΞSSIONS 001]",
-        "subtitle": "Full headline set recording",
+        "subtitle": "Live Festival Performance",
         "duration": "52 min",
         "views": 348000,
         "thumbnail": "https://images.unsplash.com/photo-1506157786151-b8491531f063",
@@ -3447,7 +3447,7 @@
       },
       "featuredVideo": {
         "title": "NERVO Live @ Tomorrowland 2018",
-        "subtitle": "Full headline set recording",
+        "subtitle": "Live Festival Performance",
         "duration": "53 min",
         "views": 375000,
         "thumbnail": "https://images.unsplash.com/photo-1492684223066-81342ee5ff30",
@@ -3787,8 +3787,8 @@
         "coverImage": "https://images.unsplash.com/photo-1492684223066-81342ee5ff30"
       },
       "featuredVideo": {
-        "title": "Wanderlust (Official Music Video)",
-        "subtitle": "Full headline set recording",
+        "title": "Wanderlust",
+        "subtitle": "Official Music Video",
         "duration": "54 min",
         "views": 402000,
         "thumbnail": "https://images.unsplash.com/photo-1516450360452-9312f5e86fc7",
@@ -4129,7 +4129,7 @@
       },
       "featuredVideo": {
         "title": "Ultra Music Festival Miami 2026 - Resistance Megastructure",
-        "subtitle": "Full headline set recording",
+        "subtitle": "Live Festival Performance",
         "duration": "55 min",
         "views": 429000,
         "thumbnail": "https://images.unsplash.com/photo-1540039155733-5bb30b53aa14",
@@ -4469,8 +4469,8 @@
         "coverImage": "https://images.unsplash.com/photo-1540039155733-5bb30b53aa14"
       },
       "featuredVideo": {
-        "title": "Timmy Trumpet x Frank Walker (feat. John Martin) - All My Life [Official Audio]",
-        "subtitle": "Full headline set recording",
+        "title": "Timmy Trumpet x Frank Walker (feat. John Martin) - All My Life",
+        "subtitle": "Official Audio Release",
         "duration": "56 min",
         "views": 456000,
         "thumbnail": "https://images.unsplash.com/photo-1501386761578-eac5c94b800a",
@@ -4811,7 +4811,7 @@
       },
       "featuredVideo": {
         "title": "ULTRA MUSIC FESTIVAL MIAMI 2025",
-        "subtitle": "Full headline set recording",
+        "subtitle": "Live Festival Performance",
         "duration": "57 min",
         "views": 483000,
         "thumbnail": "https://images.unsplash.com/photo-1514525253161-7a46d19cd819",

--- a/src/data/djscovery_seed_2.json
+++ b/src/data/djscovery_seed_2.json
@@ -20,12 +20,7 @@
       "url": "https://images.unsplash.com/photo-1514525253161-7a46d19cd819",
       "alt": "Mira Sol live performance cover"
     },
-    "genres": [
-      "Deep House",
-      "Organic House",
-      "Downtempo",
-      "Melodic House"
-    ],
+    "genres": ["Deep House", "Organic House", "Downtempo", "Melodic House"],
     "socials": {
       "instagram": "https://www.instagram.com/mirasolmusic/",
       "soundcloud": "https://soundcloud.com/user-635857713",
@@ -44,23 +39,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "Deep House Sessions Vol.4",
+        "title": "swuuuaaahhhhhg",
         "duration": "59m",
         "plays": 48345,
-        "genres": [
-          "Deep House",
-          "Organic House"
-        ],
-        "audioUrl": "https://soundcloud.com/mira-sol/deep-house-sessions",
+        "genres": ["Deep House", "Organic House"],
+        "audioUrl": "https://soundcloud.com/user-635857713/sets/swuuuaaahhhhhg?si=d8587947018a480b8c5f4782e02dbfc8&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3"
       },
       "featuredVideo": {
-        "title": "Live @ Fabric London 2025",
+        "title": "Why I Still Miss You",
         "subtitle": "Full headline set recording",
         "duration": "43 min",
         "views": 105000,
         "thumbnail": "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/fZXUfs0NV-Y?si=pZuLvwsU80Z73ESK"
       }
     },
     "analytics": {
@@ -139,38 +131,9 @@
     "availability": {
       "timezone": "Europe/Stockholm",
       "month": "2025-09",
-      "availableDays": [
-        1,
-        2,
-        3,
-        8,
-        9,
-        10,
-        15,
-        16,
-        17,
-        22,
-        23,
-        24,
-        29,
-        30
-      ],
-      "bookedDays": [
-        5,
-        6,
-        12,
-        13,
-        19,
-        20,
-        26,
-        27
-      ],
-      "tentativeDays": [
-        4,
-        11,
-        18,
-        25
-      ]
+      "availableDays": [1, 2, 3, 8, 9, 10, 15, 16, 17, 22, 23, 24, 29, 30],
+      "bookedDays": [5, 6, 12, 13, 19, 20, 26, 27],
+      "tentativeDays": [4, 11, 18, 25]
     },
     "packages": [
       {
@@ -212,12 +175,7 @@
       }
     ],
     "bio": "Mira Sol brings sunset-driven deep house and organic grooves to international dancefloors. Known for sharp transitions, crowd reading, and memorable peak-time moments, Mira Sol has built a reputation across clubs, festivals, and private events.",
-    "specialties": [
-      "Festival",
-      "Club",
-      "Corporate",
-      "Private Events"
-    ],
+    "specialties": ["Festival", "Club", "Corporate", "Private Events"],
     "media": {
       "photos": [
         "https://images.unsplash.com/photo-1514525253161-7a46d19cd819",
@@ -403,12 +361,7 @@
       "url": "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3",
       "alt": "Kai Frequency live performance cover"
     },
-    "genres": [
-      "Techno",
-      "Melodic Techno",
-      "House",
-      "Electronica"
-    ],
+    "genres": ["Techno", "Melodic Techno", "House", "Electronica"],
     "socials": {
       "spotify": "https://open.spotify.com/track/5D7zgku43yFawUZ0Rpbn8H",
       "apple": "https://music.apple.com/fj/artist/dj-kai/1815815836"
@@ -427,10 +380,7 @@
         "title": "Techno Sessions Vol.5",
         "duration": "60m",
         "plays": 60690,
-        "genres": [
-          "Techno",
-          "Melodic Techno"
-        ],
+        "genres": ["Techno", "Melodic Techno"],
         "audioUrl": "https://soundcloud.com/kai-frequency/techno-sessions",
         "coverImage": "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f"
       },
@@ -519,38 +469,9 @@
     "availability": {
       "timezone": "Europe/Stockholm",
       "month": "2025-09",
-      "availableDays": [
-        1,
-        2,
-        3,
-        8,
-        9,
-        10,
-        15,
-        16,
-        17,
-        22,
-        23,
-        24,
-        29,
-        30
-      ],
-      "bookedDays": [
-        5,
-        6,
-        12,
-        13,
-        19,
-        20,
-        26,
-        27
-      ],
-      "tentativeDays": [
-        4,
-        11,
-        18,
-        25
-      ]
+      "availableDays": [1, 2, 3, 8, 9, 10, 15, 16, 17, 22, 23, 24, 29, 30],
+      "bookedDays": [5, 6, 12, 13, 19, 20, 26, 27],
+      "tentativeDays": [4, 11, 18, 25]
     },
     "packages": [
       {
@@ -592,12 +513,7 @@
       }
     ],
     "bio": "Kai Frequency brings clean melodic techno with futuristic Seoul club energy to international dancefloors. Known for sharp transitions, crowd reading, and memorable peak-time moments, Kai Frequency has built a reputation across clubs, festivals, and private events.",
-    "specialties": [
-      "Festival",
-      "Club",
-      "Corporate",
-      "Private Events"
-    ],
+    "specialties": ["Festival", "Club", "Corporate", "Private Events"],
     "media": {
       "photos": [
         "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3",
@@ -783,12 +699,7 @@
       "url": "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f",
       "alt": "Sahara Beats live performance cover"
     },
-    "genres": [
-      "Afro House",
-      "Organic House",
-      "Arab Electronic",
-      "Deep House"
-    ],
+    "genres": ["Afro House", "Organic House", "Arab Electronic", "Deep House"],
     "socials": {
       "soundcloud": "https://soundcloud.com/djsahara",
       "youtube": "https://www.youtube.com/@ArabesqueEcho"
@@ -804,23 +715,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "Afro House Sessions Vol.6",
+        "title": "D j Sahara Commercial Top,Hits,New,Best Mix 2015",
         "duration": "61m",
         "plays": 73035,
-        "genres": [
-          "Afro House",
-          "Organic House"
-        ],
-        "audioUrl": "https://soundcloud.com/sahara-beats/afro-house-sessions",
+        "genres": ["Afro House", "Organic House"],
+        "audioUrl": "https://soundcloud.com/djsahara/d-j-sahara-commercial-tophitsnewbest-mix-2015?si=92de6d28df7c4a1b9148fe7e48305459&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1506157786151-b8491531f063"
       },
       "featuredVideo": {
-        "title": "Live @ Club Space 2025",
+        "title": "Late Night Mirage 2026 | Arabic EDM × Balkan Chill Progressive Mix 🌙",
         "subtitle": "Full headline set recording",
         "duration": "45 min",
         "views": 159000,
         "thumbnail": "https://images.unsplash.com/photo-1492684223066-81342ee5ff30",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/lHBiiJzdUss?si=zFC8JIaKneIcglYM"
       }
     },
     "analytics": {
@@ -899,38 +807,9 @@
     "availability": {
       "timezone": "Europe/Stockholm",
       "month": "2025-09",
-      "availableDays": [
-        1,
-        2,
-        3,
-        8,
-        9,
-        10,
-        15,
-        16,
-        17,
-        22,
-        23,
-        24,
-        29,
-        30
-      ],
-      "bookedDays": [
-        5,
-        6,
-        12,
-        13,
-        19,
-        20,
-        26,
-        27
-      ],
-      "tentativeDays": [
-        4,
-        11,
-        18,
-        25
-      ]
+      "availableDays": [1, 2, 3, 8, 9, 10, 15, 16, 17, 22, 23, 24, 29, 30],
+      "bookedDays": [5, 6, 12, 13, 19, 20, 26, 27],
+      "tentativeDays": [4, 11, 18, 25]
     },
     "packages": [
       {
@@ -972,12 +851,7 @@
       }
     ],
     "bio": "Sahara Beats brings North African rhythms, Afro House, and warm desert-inspired percussion to international dancefloors. Known for sharp transitions, crowd reading, and memorable peak-time moments, Sahara Beats has built a reputation across clubs, festivals, and private events.",
-    "specialties": [
-      "Festival",
-      "Club",
-      "Corporate",
-      "Private Events"
-    ],
+    "specialties": ["Festival", "Club", "Corporate", "Private Events"],
     "media": {
       "photos": [
         "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f",
@@ -1163,12 +1037,7 @@
       "url": "https://images.unsplash.com/photo-1506157786151-b8491531f063",
       "alt": "Rio Noir live performance cover"
     },
-    "genres": [
-      "Baile Funk",
-      "Latin House",
-      "Tech House",
-      "Bass"
-    ],
+    "genres": ["Baile Funk", "Latin House", "Tech House", "Bass"],
     "socials": {
       "instagram": "https://www.instagram.com/rionoir/",
       "soundcloud": "https://soundcloud.com/rionoirmusic",
@@ -1185,14 +1054,11 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "Baile Funk Sessions Vol.7",
+        "title": "Shake The Disease",
         "duration": "62m",
         "plays": 85380,
-        "genres": [
-          "Baile Funk",
-          "Latin House"
-        ],
-        "audioUrl": "https://soundcloud.com/rio-noir/baile-funk-sessions",
+        "genres": ["Baile Funk", "Latin House"],
+        "audioUrl": "https://soundcloud.com/rionoirmusic/shake-the-disease?si=c3356aa4a54f4eb98240e9fff9dbb12a&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1492684223066-81342ee5ff30"
       },
       "featuredVideo": {
@@ -1280,38 +1146,9 @@
     "availability": {
       "timezone": "Europe/Stockholm",
       "month": "2025-09",
-      "availableDays": [
-        1,
-        2,
-        3,
-        8,
-        9,
-        10,
-        15,
-        16,
-        17,
-        22,
-        23,
-        24,
-        29,
-        30
-      ],
-      "bookedDays": [
-        5,
-        6,
-        12,
-        13,
-        19,
-        20,
-        26,
-        27
-      ],
-      "tentativeDays": [
-        4,
-        11,
-        18,
-        25
-      ]
+      "availableDays": [1, 2, 3, 8, 9, 10, 15, 16, 17, 22, 23, 24, 29, 30],
+      "bookedDays": [5, 6, 12, 13, 19, 20, 26, 27],
+      "tentativeDays": [4, 11, 18, 25]
     },
     "packages": [
       {
@@ -1353,12 +1190,7 @@
       }
     ],
     "bio": "Rio Noir brings Brazilian street energy mixed with club-ready Latin House to international dancefloors. Known for sharp transitions, crowd reading, and memorable peak-time moments, Rio Noir has built a reputation across clubs, festivals, and private events.",
-    "specialties": [
-      "Festival",
-      "Club",
-      "Corporate",
-      "Private Events"
-    ],
+    "specialties": ["Festival", "Club", "Corporate", "Private Events"],
     "media": {
       "photos": [
         "https://images.unsplash.com/photo-1506157786151-b8491531f063",
@@ -1544,12 +1376,7 @@
       "url": "https://images.unsplash.com/photo-1492684223066-81342ee5ff30",
       "alt": "Zara Luxe live performance cover"
     },
-    "genres": [
-      "Open Format",
-      "Commercial",
-      "Afro House",
-      "R&B"
-    ],
+    "genres": ["Open Format", "Commercial", "Afro House", "R&B"],
     "socials": {
       "instagram": "https://www.instagram.com/zaradj_/?hl=en",
       "soundcloud": "https://soundcloud.com/dj-zara-1",
@@ -1567,23 +1394,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "Open Format Sessions Vol.8",
+        "title": "Afrojack & Shermanology - Cant Stop Me ( Zära Teaser Mix )",
         "duration": "63m",
         "plays": 97725,
-        "genres": [
-          "Open Format",
-          "Commercial"
-        ],
-        "audioUrl": "https://soundcloud.com/zara-luxe/open-format-sessions",
+        "genres": ["Open Format", "Commercial"],
+        "audioUrl": "https://soundcloud.com/dj-zara-1/afrojack-shermanology-cant?si=d166237b38804222bed84df63f6b4b17&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1516450360452-9312f5e86fc7"
       },
       "featuredVideo": {
-        "title": "Live @ Shelter NYC 2025",
+        "title": "Cubano House 🔥 Afro Latin Club Groove",
         "subtitle": "Full headline set recording",
         "duration": "47 min",
         "views": 213000,
         "thumbnail": "https://images.unsplash.com/photo-1540039155733-5bb30b53aa14",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/QkY4jwwGrZI?si=cA7Vnj6Z3rFQWeqM"
       }
     },
     "analytics": {
@@ -1662,38 +1486,9 @@
     "availability": {
       "timezone": "Europe/Stockholm",
       "month": "2025-09",
-      "availableDays": [
-        1,
-        2,
-        3,
-        8,
-        9,
-        10,
-        15,
-        16,
-        17,
-        22,
-        23,
-        24,
-        29,
-        30
-      ],
-      "bookedDays": [
-        5,
-        6,
-        12,
-        13,
-        19,
-        20,
-        26,
-        27
-      ],
-      "tentativeDays": [
-        4,
-        11,
-        18,
-        25
-      ]
+      "availableDays": [1, 2, 3, 8, 9, 10, 15, 16, 17, 22, 23, 24, 29, 30],
+      "bookedDays": [5, 6, 12, 13, 19, 20, 26, 27],
+      "tentativeDays": [4, 11, 18, 25]
     },
     "packages": [
       {
@@ -1735,12 +1530,7 @@
       }
     ],
     "bio": "Zara Luxe brings luxury event energy, open-format transitions, and premium club selections to international dancefloors. Known for sharp transitions, crowd reading, and memorable peak-time moments, Zara Luxe has built a reputation across clubs, festivals, and private events.",
-    "specialties": [
-      "Festival",
-      "Club",
-      "Corporate",
-      "Private Events"
-    ],
+    "specialties": ["Festival", "Club", "Corporate", "Private Events"],
     "media": {
       "photos": [
         "https://images.unsplash.com/photo-1492684223066-81342ee5ff30",
@@ -1926,12 +1716,7 @@
       "url": "https://images.unsplash.com/photo-1516450360452-9312f5e86fc7",
       "alt": "Armin van Buuren live performance cover"
     },
-    "genres": [
-      "Trance",
-      "Progressive Trance",
-      "EDM",
-      "Progressive House"
-    ],
+    "genres": ["Trance", "Progressive Trance", "EDM", "Progressive House"],
     "socials": {
       "instagram": "https://www.instagram.com/arminvanbuuren/?hl=en",
       "soundcloud": "https://soundcloud.com/arminvanbuuren",
@@ -1950,23 +1735,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "Trance Sessions Vol.3",
+        "title": "A State of Trance 25 Years - Selected Highlights (Mixed by Armin van Buuren)",
         "duration": "64m",
         "plays": 110070,
-        "genres": [
-          "Trance",
-          "Progressive Trance"
-        ],
-        "audioUrl": "https://soundcloud.com/armin-van-buuren/trance-sessions",
+        "genres": ["Trance", "Progressive Trance"],
+        "audioUrl": "https://soundcloud.com/arminvanbuuren/sets/a-state-of-trance-25-years?si=c1752a1397d74de686e40d756b26cc7b&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1540039155733-5bb30b53aa14"
       },
       "featuredVideo": {
-        "title": "Live @ Berns 2025",
+        "title": "Armin van Buuren & Olive Anguz - Vem Comigo (Official Music Video)",
         "subtitle": "Full headline set recording",
         "duration": "48 min",
         "views": 240000,
         "thumbnail": "https://images.unsplash.com/photo-1501386761578-eac5c94b800a",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/EIL4UJBvxuM?si=7wpOdEGYC4whMJWQ"
       }
     },
     "analytics": {
@@ -2045,38 +1827,9 @@
     "availability": {
       "timezone": "Europe/Stockholm",
       "month": "2025-09",
-      "availableDays": [
-        1,
-        2,
-        3,
-        8,
-        9,
-        10,
-        15,
-        16,
-        17,
-        22,
-        23,
-        24,
-        29,
-        30
-      ],
-      "bookedDays": [
-        5,
-        6,
-        12,
-        13,
-        19,
-        20,
-        26,
-        27
-      ],
-      "tentativeDays": [
-        4,
-        11,
-        18,
-        25
-      ]
+      "availableDays": [1, 2, 3, 8, 9, 10, 15, 16, 17, 22, 23, 24, 29, 30],
+      "bookedDays": [5, 6, 12, 13, 19, 20, 26, 27],
+      "tentativeDays": [4, 11, 18, 25]
     },
     "packages": [
       {
@@ -2118,12 +1871,7 @@
       }
     ],
     "bio": "Armin van Buuren brings uplifting trance, emotional builds, and festival-scale energy to international dancefloors. Known for sharp transitions, crowd reading, and memorable peak-time moments, Armin van Buuren has built a reputation across clubs, festivals, and private events.",
-    "specialties": [
-      "Festival",
-      "Club",
-      "Corporate",
-      "Private Events"
-    ],
+    "specialties": ["Festival", "Club", "Corporate", "Private Events"],
     "media": {
       "photos": [
         "https://images.unsplash.com/photo-1516450360452-9312f5e86fc7",
@@ -2309,12 +2057,7 @@
       "url": "https://images.unsplash.com/photo-1540039155733-5bb30b53aa14",
       "alt": "Tiësto live performance cover"
     },
-    "genres": [
-      "EDM",
-      "House",
-      "Progressive House",
-      "Electro House"
-    ],
+    "genres": ["EDM", "House", "Progressive House", "Electro House"],
     "socials": {
       "instagram": "https://www.instagram.com/tiesto/?hl=en",
       "soundcloud": "https://soundcloud.com/tiesto",
@@ -2333,23 +2076,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "EDM Sessions Vol.4",
+        "title": "Bring Me To Life",
         "duration": "65m",
         "plays": 122415,
-        "genres": [
-          "EDM",
-          "House"
-        ],
-        "audioUrl": "https://soundcloud.com/tiesto/edm-sessions",
+        "genres": ["EDM", "House"],
+        "audioUrl": "https://soundcloud.com/tiesto/bring-me-to-life?si=58a8b86d96d24cfc80688d01092f5d6f&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1501386761578-eac5c94b800a"
       },
       "featuredVideo": {
-        "title": "Live @ DC-10 2025",
+        "title": "Tiësto Live at EDC Las Vegas 2026",
         "subtitle": "Full headline set recording",
         "duration": "49 min",
         "views": 267000,
         "thumbnail": "https://images.unsplash.com/photo-1514525253161-7a46d19cd819",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://www.youtube.com/live/kG0SVvz9e-g?si=7swNmz9r1hyUmmz6"
       }
     },
     "analytics": {
@@ -2428,38 +2168,9 @@
     "availability": {
       "timezone": "Europe/Stockholm",
       "month": "2025-09",
-      "availableDays": [
-        1,
-        2,
-        3,
-        8,
-        9,
-        10,
-        15,
-        16,
-        17,
-        22,
-        23,
-        24,
-        29,
-        30
-      ],
-      "bookedDays": [
-        5,
-        6,
-        12,
-        13,
-        19,
-        20,
-        26,
-        27
-      ],
-      "tentativeDays": [
-        4,
-        11,
-        18,
-        25
-      ]
+      "availableDays": [1, 2, 3, 8, 9, 10, 15, 16, 17, 22, 23, 24, 29, 30],
+      "bookedDays": [5, 6, 12, 13, 19, 20, 26, 27],
+      "tentativeDays": [4, 11, 18, 25]
     },
     "packages": [
       {
@@ -2501,12 +2212,7 @@
       }
     ],
     "bio": "Tiësto brings mainstage EDM with polished house and festival impact to international dancefloors. Known for sharp transitions, crowd reading, and memorable peak-time moments, Tiësto has built a reputation across clubs, festivals, and private events.",
-    "specialties": [
-      "Festival",
-      "Club",
-      "Corporate",
-      "Private Events"
-    ],
+    "specialties": ["Festival", "Club", "Corporate", "Private Events"],
     "media": {
       "photos": [
         "https://images.unsplash.com/photo-1540039155733-5bb30b53aa14",
@@ -2692,12 +2398,7 @@
       "url": "https://images.unsplash.com/photo-1501386761578-eac5c94b800a",
       "alt": "David Guetta live performance cover"
     },
-    "genres": [
-      "EDM",
-      "Pop Dance",
-      "Electro House",
-      "Commercial"
-    ],
+    "genres": ["EDM", "Pop Dance", "Electro House", "Commercial"],
     "socials": {
       "instagram": "https://www.instagram.com/davidguetta/?hl=en",
       "soundcloud": "https://soundcloud.com/davidguetta",
@@ -2715,23 +2416,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "EDM Sessions Vol.5",
+        "title": "Babylon (Men Machine Rework)",
         "duration": "66m",
         "plays": 134760,
-        "genres": [
-          "EDM",
-          "Pop Dance"
-        ],
-        "audioUrl": "https://soundcloud.com/david-guetta/edm-sessions",
+        "genres": ["EDM", "Pop Dance"],
+        "audioUrl": "https://soundcloud.com/davidguetta/babylon-men-machine-rework?si=0b8b00a75a37495a83142ba6c79f28f5&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1514525253161-7a46d19cd819"
       },
       "featuredVideo": {
-        "title": "Live @ Rex Club 2025",
+        "title": "David Guetta & Hypaton - Walked Away (Live Performance @ Tomorrowland 2025)",
         "subtitle": "Full headline set recording",
         "duration": "50 min",
         "views": 294000,
         "thumbnail": "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/SBz87t9u55s?si=_30hXnpPZanTnlBA"
       }
     },
     "analytics": {
@@ -2810,38 +2508,9 @@
     "availability": {
       "timezone": "Europe/Stockholm",
       "month": "2025-09",
-      "availableDays": [
-        1,
-        2,
-        3,
-        8,
-        9,
-        10,
-        15,
-        16,
-        17,
-        22,
-        23,
-        24,
-        29,
-        30
-      ],
-      "bookedDays": [
-        5,
-        6,
-        12,
-        13,
-        19,
-        20,
-        26,
-        27
-      ],
-      "tentativeDays": [
-        4,
-        11,
-        18,
-        25
-      ]
+      "availableDays": [1, 2, 3, 8, 9, 10, 15, 16, 17, 22, 23, 24, 29, 30],
+      "bookedDays": [5, 6, 12, 13, 19, 20, 26, 27],
+      "tentativeDays": [4, 11, 18, 25]
     },
     "packages": [
       {
@@ -2883,12 +2552,7 @@
       }
     ],
     "bio": "David Guetta brings global pop-dance energy and radio-ready festival moments to international dancefloors. Known for sharp transitions, crowd reading, and memorable peak-time moments, David Guetta has built a reputation across clubs, festivals, and private events.",
-    "specialties": [
-      "Festival",
-      "Club",
-      "Corporate",
-      "Private Events"
-    ],
+    "specialties": ["Festival", "Club", "Corporate", "Private Events"],
     "media": {
       "photos": [
         "https://images.unsplash.com/photo-1501386761578-eac5c94b800a",
@@ -3074,12 +2738,7 @@
       "url": "https://images.unsplash.com/photo-1514525253161-7a46d19cd819",
       "alt": "Alok live performance cover"
     },
-    "genres": [
-      "Brazilian Bass",
-      "House",
-      "Dance Pop",
-      "EDM"
-    ],
+    "genres": ["Brazilian Bass", "House", "Dance Pop", "EDM"],
     "socials": {
       "instagram": "https://www.instagram.com/alok/?hl=en",
       "soundcloud": "https://soundcloud.com/livealok",
@@ -3098,23 +2757,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "Brazilian Bass Sessions Vol.6",
+        "title": "Run Run River (Angels Above Me)",
         "duration": "67m",
         "plays": 147105,
-        "genres": [
-          "Brazilian Bass",
-          "House"
-        ],
-        "audioUrl": "https://soundcloud.com/alok/brazilian-bass-sessions",
+        "genres": ["Brazilian Bass", "House"],
+        "audioUrl": "https://soundcloud.com/livealok/run-run-river-angels-above-me?si=4233c82bb2644e34ad4f6d1a16907f50&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3"
       },
       "featuredVideo": {
-        "title": "Live @ Watergate 2025",
+        "title": "Alok b2b Green Velvet @ EDC Orlando 2025",
         "subtitle": "Full headline set recording",
         "duration": "51 min",
         "views": 321000,
         "thumbnail": "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/iY4g1WaBmds?si=_m1UiaATv329X5RC"
       }
     },
     "analytics": {
@@ -3193,38 +2849,9 @@
     "availability": {
       "timezone": "Europe/Stockholm",
       "month": "2025-09",
-      "availableDays": [
-        1,
-        2,
-        3,
-        8,
-        9,
-        10,
-        15,
-        16,
-        17,
-        22,
-        23,
-        24,
-        29,
-        30
-      ],
-      "bookedDays": [
-        5,
-        6,
-        12,
-        13,
-        19,
-        20,
-        26,
-        27
-      ],
-      "tentativeDays": [
-        4,
-        11,
-        18,
-        25
-      ]
+      "availableDays": [1, 2, 3, 8, 9, 10, 15, 16, 17, 22, 23, 24, 29, 30],
+      "bookedDays": [5, 6, 12, 13, 19, 20, 26, 27],
+      "tentativeDays": [4, 11, 18, 25]
     },
     "packages": [
       {
@@ -3266,12 +2893,7 @@
       }
     ],
     "bio": "Alok brings Brazilian bass, emotional hooks, and modern house production to international dancefloors. Known for sharp transitions, crowd reading, and memorable peak-time moments, Alok has built a reputation across clubs, festivals, and private events.",
-    "specialties": [
-      "Festival",
-      "Club",
-      "Corporate",
-      "Private Events"
-    ],
+    "specialties": ["Festival", "Club", "Corporate", "Private Events"],
     "media": {
       "photos": [
         "https://images.unsplash.com/photo-1514525253161-7a46d19cd819",
@@ -3457,12 +3079,7 @@
       "url": "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3",
       "alt": "Don Diablo live performance cover"
     },
-    "genres": [
-      "Future House",
-      "EDM",
-      "Electro House",
-      "Dance"
-    ],
+    "genres": ["Future House", "EDM", "Electro House", "Dance"],
     "socials": {
       "instagram": "https://www.instagram.com/dondiablo/?hl=en",
       "soundcloud": "https://soundcloud.com/DONDIABLO",
@@ -3480,23 +3097,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "Future House Sessions Vol.7",
+        "title": "Brighter Days (Don Diablo ReHex)",
         "duration": "68m",
         "plays": 159450,
-        "genres": [
-          "Future House",
-          "EDM"
-        ],
-        "audioUrl": "https://soundcloud.com/don-diablo/future-house-sessions",
+        "genres": ["Future House", "EDM"],
+        "audioUrl": "https://soundcloud.com/dondiablo/brighterdaysrehex?in=dondiablo/sets/rehexes&si=85c421c6ba424ea6bb7490497cf30944&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f"
       },
       "featuredVideo": {
-        "title": "Live @ Ministry of Sound 2025",
+        "title": "Don Diablo, Wiz Khalifa & Chri$tian Gate$ - Go Home With A Stranger [LA SΞSSIONS 001]",
         "subtitle": "Full headline set recording",
         "duration": "52 min",
         "views": 348000,
         "thumbnail": "https://images.unsplash.com/photo-1506157786151-b8491531f063",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/fcYmegOL1Bg?si=d6lDd-mbw4YR5XP-"
       }
     },
     "analytics": {
@@ -3575,38 +3189,9 @@
     "availability": {
       "timezone": "Europe/Stockholm",
       "month": "2025-09",
-      "availableDays": [
-        1,
-        2,
-        3,
-        8,
-        9,
-        10,
-        15,
-        16,
-        17,
-        22,
-        23,
-        24,
-        29,
-        30
-      ],
-      "bookedDays": [
-        5,
-        6,
-        12,
-        13,
-        19,
-        20,
-        26,
-        27
-      ],
-      "tentativeDays": [
-        4,
-        11,
-        18,
-        25
-      ]
+      "availableDays": [1, 2, 3, 8, 9, 10, 15, 16, 17, 22, 23, 24, 29, 30],
+      "bookedDays": [5, 6, 12, 13, 19, 20, 26, 27],
+      "tentativeDays": [4, 11, 18, 25]
     },
     "packages": [
       {
@@ -3648,12 +3233,7 @@
       }
     ],
     "bio": "Don Diablo brings future house, digital aesthetics, and high-energy dancefloor control to international dancefloors. Known for sharp transitions, crowd reading, and memorable peak-time moments, Don Diablo has built a reputation across clubs, festivals, and private events.",
-    "specialties": [
-      "Festival",
-      "Club",
-      "Corporate",
-      "Private Events"
-    ],
+    "specialties": ["Festival", "Club", "Corporate", "Private Events"],
     "media": {
       "photos": [
         "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3",
@@ -3839,12 +3419,7 @@
       "url": "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f",
       "alt": "NERVO live performance cover"
     },
-    "genres": [
-      "EDM",
-      "Electro House",
-      "Progressive House",
-      "Dance Pop"
-    ],
+    "genres": ["EDM", "Electro House", "Progressive House", "Dance Pop"],
     "socials": {
       "instagram": "https://www.instagram.com/nervomusic/?hl=en",
       "soundcloud": "https://soundcloud.com/marco-dachille",
@@ -3863,23 +3438,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "EDM Sessions Vol.8",
+        "title": "LOCKDOWN-tempo #1 - Once Upon A Time",
         "duration": "69m",
         "plays": 171795,
-        "genres": [
-          "EDM",
-          "Electro House"
-        ],
-        "audioUrl": "https://soundcloud.com/nervo/edm-sessions",
+        "genres": ["EDM", "Electro House"],
+        "audioUrl": "https://soundcloud.com/marco-dachille/lockdown-tempo-1-once-upon-a-time?si=97c9dd965e3a4ad0a45920bff7580053&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1506157786151-b8491531f063"
       },
       "featuredVideo": {
-        "title": "Live @ Amnesia 2025",
+        "title": "NERVO Live @ Tomorrowland 2018",
         "subtitle": "Full headline set recording",
         "duration": "53 min",
         "views": 375000,
         "thumbnail": "https://images.unsplash.com/photo-1492684223066-81342ee5ff30",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/Ifwz5BgY4eA?si=jRIORIhsSANxETRw"
       }
     },
     "analytics": {
@@ -3958,38 +3530,9 @@
     "availability": {
       "timezone": "Europe/Stockholm",
       "month": "2025-09",
-      "availableDays": [
-        1,
-        2,
-        3,
-        8,
-        9,
-        10,
-        15,
-        16,
-        17,
-        22,
-        23,
-        24,
-        29,
-        30
-      ],
-      "bookedDays": [
-        5,
-        6,
-        12,
-        13,
-        19,
-        20,
-        26,
-        27
-      ],
-      "tentativeDays": [
-        4,
-        11,
-        18,
-        25
-      ]
+      "availableDays": [1, 2, 3, 8, 9, 10, 15, 16, 17, 22, 23, 24, 29, 30],
+      "bookedDays": [5, 6, 12, 13, 19, 20, 26, 27],
+      "tentativeDays": [4, 11, 18, 25]
     },
     "packages": [
       {
@@ -4031,12 +3574,7 @@
       }
     ],
     "bio": "NERVO brings bright EDM hooks, festival drops, and vocal-driven dance music to international dancefloors. Known for sharp transitions, crowd reading, and memorable peak-time moments, NERVO has built a reputation across clubs, festivals, and private events.",
-    "specialties": [
-      "Festival",
-      "Club",
-      "Corporate",
-      "Private Events"
-    ],
+    "specialties": ["Festival", "Club", "Corporate", "Private Events"],
     "media": {
       "photos": [
         "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f",
@@ -4222,12 +3760,7 @@
       "url": "https://images.unsplash.com/photo-1506157786151-b8491531f063",
       "alt": "Claptone live performance cover"
     },
-    "genres": [
-      "House",
-      "Deep House",
-      "Tech House",
-      "Melodic House"
-    ],
+    "genres": ["House", "Deep House", "Tech House", "Melodic House"],
     "socials": {
       "instagram": "https://www.instagram.com/claptone.official/?hl=en",
       "soundcloud": "https://soundcloud.com/claptone",
@@ -4246,23 +3779,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "House Sessions Vol.3",
+        "title": "Sandcastles",
         "duration": "70m",
         "plays": 184140,
-        "genres": [
-          "House",
-          "Deep House"
-        ],
-        "audioUrl": "https://soundcloud.com/claptone/house-sessions",
+        "genres": ["House", "Deep House"],
+        "audioUrl": "https://soundcloud.com/claptone/track-5?si=975ad8eaab8146bb8e1d7979cd4d7c96&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1492684223066-81342ee5ff30"
       },
       "featuredVideo": {
-        "title": "Live @ Berghain 2025",
+        "title": "Wanderlust (Official Music Video)",
         "subtitle": "Full headline set recording",
         "duration": "54 min",
         "views": 402000,
         "thumbnail": "https://images.unsplash.com/photo-1516450360452-9312f5e86fc7",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/jOHL5y-h-eg?si=V8bp50qYXZiGCnSX"
       }
     },
     "analytics": {
@@ -4341,38 +3871,9 @@
     "availability": {
       "timezone": "Europe/Stockholm",
       "month": "2025-09",
-      "availableDays": [
-        1,
-        2,
-        3,
-        8,
-        9,
-        10,
-        15,
-        16,
-        17,
-        22,
-        23,
-        24,
-        29,
-        30
-      ],
-      "bookedDays": [
-        5,
-        6,
-        12,
-        13,
-        19,
-        20,
-        26,
-        27
-      ],
-      "tentativeDays": [
-        4,
-        11,
-        18,
-        25
-      ]
+      "availableDays": [1, 2, 3, 8, 9, 10, 15, 16, 17, 22, 23, 24, 29, 30],
+      "bookedDays": [5, 6, 12, 13, 19, 20, 26, 27],
+      "tentativeDays": [4, 11, 18, 25]
     },
     "packages": [
       {
@@ -4414,12 +3915,7 @@
       }
     ],
     "bio": "Claptone brings mysterious house selections, deep grooves, and refined club storytelling to international dancefloors. Known for sharp transitions, crowd reading, and memorable peak-time moments, Claptone has built a reputation across clubs, festivals, and private events.",
-    "specialties": [
-      "Festival",
-      "Club",
-      "Corporate",
-      "Private Events"
-    ],
+    "specialties": ["Festival", "Club", "Corporate", "Private Events"],
     "media": {
       "photos": [
         "https://images.unsplash.com/photo-1506157786151-b8491531f063",
@@ -4605,12 +4101,7 @@
       "url": "https://images.unsplash.com/photo-1492684223066-81342ee5ff30",
       "alt": "Vintage Culture live performance cover"
     },
-    "genres": [
-      "House",
-      "Deep House",
-      "Tech House",
-      "Melodic House"
-    ],
+    "genres": ["House", "Deep House", "Tech House", "Melodic House"],
     "socials": {
       "instagram": "https://www.instagram.com/vintageculture/?hl=en",
       "soundcloud": "https://soundcloud.com/vintageculturemusic",
@@ -4629,23 +4120,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "House Sessions Vol.4",
+        "title": "Do You EP",
         "duration": "71m",
         "plays": 196485,
-        "genres": [
-          "House",
-          "Deep House"
-        ],
-        "audioUrl": "https://soundcloud.com/vintage-culture/house-sessions",
+        "genres": ["House", "Deep House"],
+        "audioUrl": "https://soundcloud.com/vintageculturemusic/sets/do-you-ep-3?si=9d651c3b0a05474ab69e946219d8a3bb&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1516450360452-9312f5e86fc7"
       },
       "featuredVideo": {
-        "title": "Live @ Fabric London 2025",
+        "title": "Ultra Music Festival Miami 2026 - Resistance Megastructure",
         "subtitle": "Full headline set recording",
         "duration": "55 min",
         "views": 429000,
         "thumbnail": "https://images.unsplash.com/photo-1540039155733-5bb30b53aa14",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/xXRjglkAmq8?si=2viJUe5GK6FiYRAb"
       }
     },
     "analytics": {
@@ -4724,38 +4212,9 @@
     "availability": {
       "timezone": "Europe/Stockholm",
       "month": "2025-09",
-      "availableDays": [
-        1,
-        2,
-        3,
-        8,
-        9,
-        10,
-        15,
-        16,
-        17,
-        22,
-        23,
-        24,
-        29,
-        30
-      ],
-      "bookedDays": [
-        5,
-        6,
-        12,
-        13,
-        19,
-        20,
-        26,
-        27
-      ],
-      "tentativeDays": [
-        4,
-        11,
-        18,
-        25
-      ]
+      "availableDays": [1, 2, 3, 8, 9, 10, 15, 16, 17, 22, 23, 24, 29, 30],
+      "bookedDays": [5, 6, 12, 13, 19, 20, 26, 27],
+      "tentativeDays": [4, 11, 18, 25]
     },
     "packages": [
       {
@@ -4797,12 +4256,7 @@
       }
     ],
     "bio": "Vintage Culture brings melodic house, Brazilian warmth, and late-night festival emotion to international dancefloors. Known for sharp transitions, crowd reading, and memorable peak-time moments, Vintage Culture has built a reputation across clubs, festivals, and private events.",
-    "specialties": [
-      "Festival",
-      "Club",
-      "Corporate",
-      "Private Events"
-    ],
+    "specialties": ["Festival", "Club", "Corporate", "Private Events"],
     "media": {
       "photos": [
         "https://images.unsplash.com/photo-1492684223066-81342ee5ff30",
@@ -4988,12 +4442,7 @@
       "url": "https://images.unsplash.com/photo-1516450360452-9312f5e86fc7",
       "alt": "Timmy Trumpet live performance cover"
     },
-    "genres": [
-      "EDM",
-      "Big Room",
-      "Hard Dance",
-      "Festival"
-    ],
+    "genres": ["EDM", "Big Room", "Hard Dance", "Festival"],
     "socials": {
       "instagram": "https://www.instagram.com/timmytrumpet/?hl=en",
       "soundcloud": "https://soundcloud.com/timmytrumpet",
@@ -5012,23 +4461,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "EDM Sessions Vol.5",
+        "title": "Robin Schulz x Timmy Trumpet x KOPPY - All the Things She Said",
         "duration": "72m",
         "plays": 208830,
-        "genres": [
-          "EDM",
-          "Big Room"
-        ],
-        "audioUrl": "https://soundcloud.com/timmy-trumpet/edm-sessions",
+        "genres": ["EDM", "Big Room"],
+        "audioUrl": "https://soundcloud.com/timmytrumpet/sets/robin-schulz-x-timmy-trumpet-x?si=908ec697811f471ca638220e48cd9224&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1540039155733-5bb30b53aa14"
       },
       "featuredVideo": {
-        "title": "Live @ Pacha 2025",
+        "title": "Timmy Trumpet x Frank Walker (feat. John Martin) - All My Life [Official Audio]",
         "subtitle": "Full headline set recording",
         "duration": "56 min",
         "views": 456000,
         "thumbnail": "https://images.unsplash.com/photo-1501386761578-eac5c94b800a",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/axlkYsorFMs?si=rzsd_8D4MvZ8ivev"
       }
     },
     "analytics": {
@@ -5107,38 +4553,9 @@
     "availability": {
       "timezone": "Europe/Stockholm",
       "month": "2025-09",
-      "availableDays": [
-        1,
-        2,
-        3,
-        8,
-        9,
-        10,
-        15,
-        16,
-        17,
-        22,
-        23,
-        24,
-        29,
-        30
-      ],
-      "bookedDays": [
-        5,
-        6,
-        12,
-        13,
-        19,
-        20,
-        26,
-        27
-      ],
-      "tentativeDays": [
-        4,
-        11,
-        18,
-        25
-      ]
+      "availableDays": [1, 2, 3, 8, 9, 10, 15, 16, 17, 22, 23, 24, 29, 30],
+      "bookedDays": [5, 6, 12, 13, 19, 20, 26, 27],
+      "tentativeDays": [4, 11, 18, 25]
     },
     "packages": [
       {
@@ -5180,12 +4597,7 @@
       }
     ],
     "bio": "Timmy Trumpet brings explosive big-room EDM and live trumpet-led stage energy to international dancefloors. Known for sharp transitions, crowd reading, and memorable peak-time moments, Timmy Trumpet has built a reputation across clubs, festivals, and private events.",
-    "specialties": [
-      "Festival",
-      "Club",
-      "Corporate",
-      "Private Events"
-    ],
+    "specialties": ["Festival", "Club", "Corporate", "Private Events"],
     "media": {
       "photos": [
         "https://images.unsplash.com/photo-1516450360452-9312f5e86fc7",
@@ -5371,12 +4783,7 @@
       "url": "https://images.unsplash.com/photo-1540039155733-5bb30b53aa14",
       "alt": "Afrojack live performance cover"
     },
-    "genres": [
-      "EDM",
-      "Electro House",
-      "Dutch House",
-      "Big Room"
-    ],
+    "genres": ["EDM", "Electro House", "Dutch House", "Big Room"],
     "socials": {
       "instagram": "https://www.instagram.com/afrojack/?hl=en",
       "soundcloud": "https://soundcloud.com/afrojack",
@@ -5395,23 +4802,20 @@
     },
     "spotlight": {
       "featuredMix": {
-        "title": "EDM Sessions Vol.6",
+        "title": "Take Over Control (feat. Eva Simons) [The Remixes 2025]",
         "duration": "73m",
         "plays": 221175,
-        "genres": [
-          "EDM",
-          "Electro House"
-        ],
-        "audioUrl": "https://soundcloud.com/afrojack/edm-sessions",
+        "genres": ["EDM", "Electro House"],
+        "audioUrl": "https://soundcloud.com/afrojack/sets/take-over-control-feat-eva-5?si=a8ac3f953bcf471097cc0ea6fbfbb029&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing",
         "coverImage": "https://images.unsplash.com/photo-1501386761578-eac5c94b800a"
       },
       "featuredVideo": {
-        "title": "Live @ Club Space 2025",
+        "title": "ULTRA MUSIC FESTIVAL MIAMI 2025",
         "subtitle": "Full headline set recording",
         "duration": "57 min",
         "views": 483000,
         "thumbnail": "https://images.unsplash.com/photo-1514525253161-7a46d19cd819",
-        "videoUrl": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        "videoUrl": "https://youtu.be/gWd3YaBsxvs?si=49VkA1IfB5H5CzBV"
       }
     },
     "analytics": {
@@ -5490,38 +4894,9 @@
     "availability": {
       "timezone": "Europe/Stockholm",
       "month": "2025-09",
-      "availableDays": [
-        1,
-        2,
-        3,
-        8,
-        9,
-        10,
-        15,
-        16,
-        17,
-        22,
-        23,
-        24,
-        29,
-        30
-      ],
-      "bookedDays": [
-        5,
-        6,
-        12,
-        13,
-        19,
-        20,
-        26,
-        27
-      ],
-      "tentativeDays": [
-        4,
-        11,
-        18,
-        25
-      ]
+      "availableDays": [1, 2, 3, 8, 9, 10, 15, 16, 17, 22, 23, 24, 29, 30],
+      "bookedDays": [5, 6, 12, 13, 19, 20, 26, 27],
+      "tentativeDays": [4, 11, 18, 25]
     },
     "packages": [
       {
@@ -5563,12 +4938,7 @@
       }
     ],
     "bio": "Afrojack brings Dutch house, powerful festival drops, and sharp electro-house production to international dancefloors. Known for sharp transitions, crowd reading, and memorable peak-time moments, Afrojack has built a reputation across clubs, festivals, and private events.",
-    "specialties": [
-      "Festival",
-      "Club",
-      "Corporate",
-      "Private Events"
-    ],
+    "specialties": ["Festival", "Club", "Corporate", "Private Events"],
     "media": {
       "photos": [
         "https://images.unsplash.com/photo-1540039155733-5bb30b53aa14",


### PR DESCRIPTION
…and add podomatic.net to image domains

- Add `assets.podomatic.net` to remote image patterns in next.config
- Prefix DJ stage names with "Dj" in both free and premium profile components
- Add z-index to profile header elements to prevent overlap issues
- Update demo DJ profiles with authentic SoundCloud, YouTube, and social media links
- Replace placeholder mix/video titles and URLs with real content from DJ profiles
- Update Am

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated DJ profile headers to display "Dj" prefix before artist stage names

* **Chores**
  * Extended remote image sources configuration with new HTTPS image provider
  * Refreshed artist seed data with updated featured mixes, videos, genres, and social media links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->