### PR TITLE
refactor: update color scheme from h_red to red-300/400 variants and …

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -66,7 +66,7 @@ const Hero = async () => {
                   <Button
                     asChild
                     variant="outline"
-                    className="border-h_red text-h_red hover:bg-h_red hover:text-white font-semibold h-auto py-3 px-6 text-sm md:text-base"
+                    className="border-h_red text-red-300 hover:bg-h_red hover:text-white font-semibold h-auto py-3 px-6 text-sm md:text-base"
                   >
                     <Link href="/directory">Browse Open Gigs</Link>
                   </Button>
@@ -82,7 +82,7 @@ const Hero = async () => {
                   <Button
                     asChild
                     variant="outline"
-                    className="border-h_red text-h_red hover:bg-h_red hover:text-white font-semibold h-auto py-3 px-6 text-sm md:text-base"
+                    className="border-h_red text-red-300 hover:bg-h_red hover:text-white font-semibold h-auto py-3 px-6 text-sm md:text-base"
                   >
                     <Link href="/directory">Find DJs</Link>
                   </Button>
@@ -98,7 +98,7 @@ const Hero = async () => {
                   <Button
                     asChild
                     variant="outline"
-                    className="border-h_red text-h_red hover:bg-h_red hover:text-white font-semibold h-auto py-3 px-6 text-sm md:text-base"
+                    className="border-h_red text-red-300 hover:bg-h_red hover:text-white font-semibold h-auto py-3 px-6 text-sm md:text-base"
                   >
                     <Link href={joinHref}>Join as Organiser</Link>
                   </Button>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -8,6 +8,8 @@ import {
   faUsers,
   faCompactDisc,
   faMagnifyingGlass,
+  faCalendarDays,
+  faTicket,
 } from "@fortawesome/free-solid-svg-icons";
 import { createClient } from "@/lib/supabase/server";
 import { Button } from "@/components/ui/button";
@@ -53,19 +55,33 @@ const Navbar = async () => {
         {/* CENTER — Nav links + Search */}
         <div className="hidden md:flex w-[50%] text-sm items-center justify-between">
           <div className="flex gap-6">
-            <Link
+            {/* <Link
               href="/"
               className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors"
             >
               <FontAwesomeIcon icon={faHouse} className="h-4 w-4" />
               <span>Home</span>
-            </Link>
+            </Link> */}
             <Link
               href="/directory"
               className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors"
             >
               <FontAwesomeIcon icon={faCompactDisc} className="h-4 w-4" />
               <span>Directory</span>
+            </Link>
+            <Link
+              href="/gigs"
+              className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors"
+            >
+              <FontAwesomeIcon icon={faCalendarDays} className="h-4 w-4" />
+              <span>Gigs</span>
+            </Link>
+            <Link
+              href="/events"
+              className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors"
+            >
+              <FontAwesomeIcon icon={faTicket} className="h-4 w-4" />
+              <span>Events</span>
             </Link>
             <Link
               href="/community"

--- a/src/components/directory/ActiveFilterBadges.tsx
+++ b/src/components/directory/ActiveFilterBadges.tsx
@@ -44,11 +44,19 @@ const ActiveFilterBadges = () => {
   type Badge = { label: string; onRemove: () => void };
 
   const badges: Badge[] = [
-    ...selectedGenres.map((g) => ({ label: g, onRemove: () => removeGenre(g) })),
+    ...selectedGenres.map((g) => ({
+      label: g,
+      onRemove: () => removeGenre(g),
+    })),
     ...(country ? [{ label: country, onRemove: removeCountry }] : []),
     ...(city ? [{ label: city, onRemove: () => removeParam("city") }] : []),
     ...(sort
-      ? [{ label: SORT_LABELS[sort] ?? sort, onRemove: () => removeParam("sort") }]
+      ? [
+          {
+            label: SORT_LABELS[sort] ?? sort,
+            onRemove: () => removeParam("sort"),
+          },
+        ]
       : []),
   ];
 
@@ -59,12 +67,12 @@ const ActiveFilterBadges = () => {
       {badges.map((badge, i) => (
         <span
           key={i}
-          className="flex items-center gap-1.5 bg-h_red/10 text-h_red text-xs px-2.5 py-1 rounded-full border border-h_red/30"
+          className="flex items-center gap-1.5 bg-h_red/10 text-red-400 text-xs px-2.5 py-1 rounded-full border border-h_red/50"
         >
           {badge.label}
           <button
             onClick={badge.onRemove}
-            className="hover:text-white transition-colors leading-none"
+            className="hover:text-white transition-colors leading-none cursor-pointer"
             aria-label={`Remove ${badge.label} filter`}
           >
             ×

--- a/src/components/directory/DjCard.tsx
+++ b/src/components/directory/DjCard.tsx
@@ -52,7 +52,7 @@ const DjCard = ({
           {genreList.slice(0, 3).map((genre) => (
             <span
               key={genre}
-              className="text-xs bg-h_red/10 text-h_red/90 px-2 py-0.5 rounded-full"
+              className="text-xs bg-h_redDark/60 text-red-200 px-2 py-0.5 rounded-full"
             >
               {genre}
             </span>
@@ -60,7 +60,7 @@ const DjCard = ({
         </div>
       )}
 
-      <button className="mt-auto bg-h_red hover:bg-h_redDark text-white text-xs px-3 py-1.5 rounded-md w-full transition-colors">
+      <button className="mt-auto bg-h_red hover:bg-h_redDark text-white text-xs px-3 py-1.5 rounded-md w-full transition-colors cursor-pointer">
         Follow
       </button>
     </div>

--- a/src/components/directory/FilterPanel.tsx
+++ b/src/components/directory/FilterPanel.tsx
@@ -166,7 +166,7 @@ const FilterPanel = ({
         </div>
 
         {/* Country */}
-        <div className="flex flex-col gap-2 w-[calc(50%-6px)] xl:w-full">
+        <div className="flex flex-col gap-2  w-[calc(50%-6px)] xl:w-full">
           <p className="text-gray-400 text-xs font-medium uppercase tracking-wider">
             Country
           </p>
@@ -175,9 +175,15 @@ const FilterPanel = ({
             onChange={(e) => updateCountry(e.target.value)}
             className="bg-h_black/50 text-gray-300 text-xs rounded-md px-3 py-2 outline-none ring-1 ring-gray-700 focus:ring-h_red"
           >
-            <option value="">All countries</option>
+            <option value="" className="bg-h_blackLight hover:bg-white/5">
+              All countries
+            </option>
             {availableCountries.map((c) => (
-              <option key={c} value={c}>
+              <option
+                key={c}
+                value={c}
+                className="bg-h_blackLight hover:bg-white/5"
+              >
                 {c}
               </option>
             ))}
@@ -195,9 +201,15 @@ const FilterPanel = ({
               onChange={(e) => updateParam("city", e.target.value)}
               className="bg-h_black/50 text-gray-300 text-xs rounded-md px-3 py-2 outline-none ring-1 ring-gray-700 focus:ring-h_red"
             >
-              <option value="">All cities</option>
+              <option value="" className="bg-h_blackLight hover:bg-white/5">
+                All cities
+              </option>
               {citiesForCountry.map((c) => (
-                <option key={c} value={c}>
+                <option
+                  key={c}
+                  value={c}
+                  className="bg-h_blackLight hover:bg-white/5"
+                >
                   {c}
                 </option>
               ))}
@@ -216,7 +228,11 @@ const FilterPanel = ({
             className="bg-h_black/50 text-gray-300 text-xs rounded-md px-3 py-2 outline-none ring-1 ring-gray-700 focus:ring-h_red"
           >
             {SORT_OPTIONS.map((o) => (
-              <option key={o.value} value={o.value}>
+              <option
+                key={o.value}
+                value={o.value}
+                className="bg-h_blackLight hover:bg-white/5"
+              >
                 {o.label}
               </option>
             ))}

--- a/src/components/home/HomeCtaBanner.tsx
+++ b/src/components/home/HomeCtaBanner.tsx
@@ -26,7 +26,7 @@ export default async function HomeCtaBanner() {
           <div className="absolute -bottom-16 -left-16 w-64 h-64 bg-h_redDark/30 rounded-full blur-3xl pointer-events-none" />
 
           <div className="relative z-10 flex flex-col items-center text-center gap-4 mb-10">
-            <span className="text-h_red text-sm font-semibold tracking-widest uppercase">
+            <span className="text-red-300 text-sm font-semibold tracking-widest uppercase">
               Join the Community
             </span>
             <h2 className="text-white text-4xl md:text-5xl leading-tight">
@@ -80,7 +80,7 @@ export default async function HomeCtaBanner() {
               <Button
                 asChild
                 variant="outline"
-                className="mt-auto border-h_red text-h_red hover:bg-h_red hover:text-white font-semibold w-full"
+                className="mt-auto border-h_red text-red-200 hover:bg-h_red hover:text-white font-semibold w-full cursor-pointer"
               >
                 <Link href={joinHref}>Join as Organiser</Link>
               </Button>

--- a/src/components/home/HomeDJsTabs.tsx
+++ b/src/components/home/HomeDJsTabs.tsx
@@ -135,7 +135,7 @@ function DJCard({
 
         <div className="flex flex-wrap gap-1 justify-center">
           {dj.genres.slice(0, 2).map((g) => (
-            <Badge key={g} className="bg-h_redDark/60 text-red-100 border-0">
+            <Badge key={g} className="bg-h_redDark/60 text-red-300 border-0">
               {g}
             </Badge>
           ))}

--- a/src/components/home/HomeEventsSection.tsx
+++ b/src/components/home/HomeEventsSection.tsx
@@ -124,7 +124,7 @@ export default function HomeEventsSection() {
                       {event.venue} · {event.city}, {event.country}
                     </span>
                   </div>
-                  <Badge className="bg-h_redDark/60 text-h_red border-0 w-fit mt-1">
+                  <Badge className="bg-h_redDark/60 text-red-300 border-0 w-fit mt-1">
                     🎧 {event.dj}
                   </Badge>
                 </div>

--- a/src/components/home/HomeFeaturedDJs.tsx
+++ b/src/components/home/HomeFeaturedDJs.tsx
@@ -90,7 +90,7 @@ export default function HomeFeaturedDJs() {
                     {dj.genres.map((g) => (
                       <Badge
                         key={g}
-                        className="bg-h_redDark/60 text-red-100 border-0"
+                        className="bg-h_redDark/60 text-red-300 border-0"
                       >
                         {g}
                       </Badge>

--- a/src/components/home/HomeOpenGigsSection.tsx
+++ b/src/components/home/HomeOpenGigsSection.tsx
@@ -76,7 +76,9 @@ export default function HomeOpenGigsSection() {
             >
               <div className="flex flex-col sm:flex-row sm:items-center gap-4">
                 <div className="shrink-0 bg-h_redDark/40 border border-h_red/30 rounded-lg px-4 py-3 text-center min-w-22.5">
-                  <p className="text-h_red font-bold text-base">{gig.budget}</p>
+                  <p className="text-red-300 font-bold text-base">
+                    {gig.budget}
+                  </p>
                   <p className="text-gray-500 text-xs">budget</p>
                 </div>
 
@@ -93,7 +95,7 @@ export default function HomeOpenGigsSection() {
                     {gig.genres.map((g) => (
                       <Badge
                         key={g}
-                        className="bg-h_redDark/60 text-red-100 border-0"
+                        className="bg-h_redDark/60 text-red-300 border-0"
                       >
                         {g}
                       </Badge>
@@ -102,12 +104,12 @@ export default function HomeOpenGigsSection() {
                 </div>
 
                 {/* This will be done with the functionalite of the gig */}
-                {/* <Button
-                size="sm"
-                className="shrink-0 bg-h_red hover:bg-h_redDark text-white"
-              >
-                Apply
-              </Button> */}
+                <Button
+                  size="sm"
+                  className="shrink-0 bg-h_red hover:bg-h_redDark text-white cursor-pointer"
+                >
+                  Apply
+                </Button>
               </div>
             </Card>
           ))}


### PR DESCRIPTION
…add Gigs/Events navigation links

- Replace `text-h_red` with `text-red-300` or `text-red-400` across Hero, ActiveFilterBadges, HomeCtaBanner, and event/gig components
- Update badge backgrounds to use `bg-h_redDark/60 text-red-300` for consistent styling
- Add cursor-pointer class to interactive buttons and filter remove actions
- Add Gigs and Events navigation links with calendar and ticket icons to Navbar
- Comment out Home link in Navbar navigation
- Add hover background styling to select

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined color scheme for badges and buttons throughout the app for improved visual consistency.
  * Enhanced navigation bar by updating center links to display Directory, Gigs, and Events more prominently.
  * Improved user experience by adding cursor pointer indicators to interactive elements.
  * Applied consistent styling to dropdown filters for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->