### PR TITLE
refactor: merge staging demo data with production database queries an…

### DIFF
--- a/src/app/directory/page.tsx
+++ b/src/app/directory/page.tsx
@@ -33,86 +33,84 @@ const DirectoryPage = async ({
   const isStaging = process.env.NEXT_PUBLIC_APP_ENV === "staging";
   let djs: DjUser[] = [];
 
-  if (!isStaging) {
-    try {
-      const profiles = await prisma.djProfile.findMany({
-        where: {
-          deletedAt: null,
-          ...(q
-            ? {
-                OR: [
-                  { stageName: { contains: q, mode: "insensitive" } },
-                  { country: { name: { contains: q, mode: "insensitive" } } },
-                  { city: { name: { contains: q, mode: "insensitive" } } },
-                  {
-                    genres: {
-                      some: {
-                        genre: { name: { contains: q, mode: "insensitive" } },
-                      },
+  try {
+    const profiles = await prisma.djProfile.findMany({
+      where: {
+        deletedAt: null,
+        ...(q
+          ? {
+              OR: [
+                { stageName: { contains: q, mode: "insensitive" } },
+                { country: { name: { contains: q, mode: "insensitive" } } },
+                { city: { name: { contains: q, mode: "insensitive" } } },
+                {
+                  genres: {
+                    some: {
+                      genre: { name: { contains: q, mode: "insensitive" } },
                     },
                   },
-                ],
-              }
-            : {}),
-
-          ...(genreList.length > 0
-            ? {
-                genres: {
-                  some: {
-                    genre: { name: { in: genreList } },
-                  },
                 },
-              }
-            : {}),
-          ...(country
-            ? { country: { name: { contains: country, mode: "insensitive" } } }
-            : {}),
-          ...(city
-            ? { city: { name: { contains: city, mode: "insensitive" } } }
-            : {}),
-          ...(djTypeList.length > 0
-            ? {
-                djTypes: {
-                  some: { type: { in: djTypeList as DjType[] } },
-                },
-              }
-            : {}),
-        },
-        orderBy:
-          sort === "a-z"
-            ? { stageName: "asc" }
-            : sort === "z-a"
-              ? { stageName: "desc" }
-              : { createdAt: "desc" },
-        include: {
-          user: {
-            include: { _count: { select: { followers: true } } },
-          },
-          country: { select: { name: true } },
-          city: { select: { name: true } },
-          genres: { include: { genre: { select: { name: true } } } },
-          djTypes: { select: { type: true } },
-        },
-      });
+              ],
+            }
+          : {}),
 
-      djs = profiles.map((p) => ({
-        id: p.userId,
-        username: p.user.username,
-        stageName: p.stageName,
-        avatar: p.avatar,
-        genres: p.genres.map((g) => g.genre.name).join(", ") || null,
-        country: p.country?.name ?? null,
-        city: p.city?.name ?? null,
-        slug: p.slug,
-        isPremium: p.plan === "PREMIUM",
-        isFeatured: p.featured,
-        verified: p.verified,
-        djTypes: p.djTypes.map((t) => t.type),
-        _count: { followers: p.user._count.followers },
-      }));
-    } catch {
-      // fetchError
-    }
+        ...(genreList.length > 0
+          ? {
+              genres: {
+                some: {
+                  genre: { name: { in: genreList } },
+                },
+              },
+            }
+          : {}),
+        ...(country
+          ? { country: { name: { contains: country, mode: "insensitive" } } }
+          : {}),
+        ...(city
+          ? { city: { name: { contains: city, mode: "insensitive" } } }
+          : {}),
+        ...(djTypeList.length > 0
+          ? {
+              djTypes: {
+                some: { type: { in: djTypeList as DjType[] } },
+              },
+            }
+          : {}),
+      },
+      orderBy:
+        sort === "a-z"
+          ? { stageName: "asc" }
+          : sort === "z-a"
+            ? { stageName: "desc" }
+            : { createdAt: "desc" },
+      include: {
+        user: {
+          include: { _count: { select: { followers: true } } },
+        },
+        country: { select: { name: true } },
+        city: { select: { name: true } },
+        genres: { include: { genre: { select: { name: true } } } },
+        djTypes: { select: { type: true } },
+      },
+    });
+
+    djs = profiles.map((p) => ({
+      id: p.userId,
+      username: p.user.username,
+      stageName: p.stageName,
+      avatar: p.avatar,
+      genres: p.genres.map((g) => g.genre.name).join(", ") || null,
+      country: p.country?.name ?? null,
+      city: p.city?.name ?? null,
+      slug: p.slug,
+      isPremium: p.plan === "PREMIUM",
+      isFeatured: p.featured,
+      verified: p.verified,
+      djTypes: p.djTypes.map((t) => t.type),
+      _count: { followers: p.user._count.followers },
+    }));
+  } catch {
+    // fetchError
   }
 
   const demoDjs = demoDJsAsDjUsers();
@@ -163,61 +161,117 @@ const DirectoryPage = async ({
   };
 
   const filteredDemoDjs = filterDemoDjs(demoDjs);
-  const displayDjs = sortDjs(isStaging ? filteredDemoDjs : djs);
+  const dbIds = new Set(djs.map((d) => d.id));
+  const displayDjs = sortDjs(
+    isStaging
+      ? [...djs, ...filteredDemoDjs.filter((d) => !dbIds.has(d.id))]
+      : djs,
+  );
 
   let availableGenres: string[] = [];
 
-  if (!isStaging) {
-    try {
-      const genres = await prisma.genre.findMany({
-        where: {
-          djGenres: {
-            some: { djProfile: { deletedAt: null } },
+  try {
+    const genres = await prisma.genre.findMany({
+      where: {
+        djGenres: {
+          some: {
+            djProfile: {
+              deletedAt: null,
+              ...(country
+                ? {
+                    country: {
+                      name: { contains: country, mode: "insensitive" },
+                    },
+                  }
+                : {}),
+              ...(city
+                ? { city: { name: { contains: city, mode: "insensitive" } } }
+                : {}),
+              ...(djTypeList.length > 0
+                ? {
+                    djTypes: {
+                      some: { type: { in: djTypeList as DjType[] } },
+                    },
+                  }
+                : {}),
+            },
           },
         },
-        orderBy: { name: "asc" },
-        select: { name: true },
-      });
-      availableGenres = genres.map((g) => g.name);
-    } catch {
-      // ignore
-    }
-  } else {
-    availableGenres = [
-      ...new Set(
-        demoDjs
-          .flatMap((dj) => (dj.genres ?? "").split(",").map((g) => g.trim()))
-          .filter(Boolean),
-      ),
-    ].sort();
+      },
+      orderBy: { name: "asc" },
+      select: { name: true },
+    });
+    availableGenres = genres.map((g) => g.name);
+  } catch {
+    // ignore
+  }
+  if (isStaging) {
+    const demoForGenres = demoDjs.filter((dj) => {
+      const countryOk = country
+        ? (dj.country ?? "").toLowerCase().includes(country.toLowerCase())
+        : true;
+      const cityOk = city
+        ? (dj.city ?? "").toLowerCase().includes(city.toLowerCase())
+        : true;
+      const djTypeOk =
+        djTypeList.length > 0
+          ? (dj.djTypes ?? []).some((t) => djTypeList.includes(t))
+          : true;
+      return countryOk && cityOk && djTypeOk;
+    });
+    const demoGenres = demoForGenres
+      .flatMap((dj) => (dj.genres ?? "").split(",").map((g) => g.trim()))
+      .filter(Boolean);
+    availableGenres = [...new Set([...availableGenres, ...demoGenres])].sort();
   }
 
   let availableCountries: string[] = [];
   let countryCities: Record<string, string[]> = {};
 
-  if (!isStaging) {
-    try {
-      const countryData = await prisma.country.findMany({
-        where: { djProfiles: { some: { deletedAt: null } } },
-        orderBy: { name: "asc" },
-        select: {
-          name: true,
-          cities: {
-            where: { djProfiles: { some: { deletedAt: null } } },
-            orderBy: { name: "asc" },
-            select: { name: true },
-          },
+  try {
+    const countryWhere = {
+      deletedAt: null as null,
+      ...(genreList.length > 0
+        ? { genres: { some: { genre: { name: { in: genreList } } } } }
+        : {}),
+      ...(djTypeList.length > 0
+        ? { djTypes: { some: { type: { in: djTypeList as DjType[] } } } }
+        : {}),
+    };
+    const countryData = await prisma.country.findMany({
+      where: { djProfiles: { some: countryWhere } },
+      orderBy: { name: "asc" },
+      select: {
+        name: true,
+        cities: {
+          where: { djProfiles: { some: countryWhere } },
+          orderBy: { name: "asc" },
+          select: { name: true },
         },
-      });
-      availableCountries = countryData.map((c) => c.name);
-      for (const c of countryData) {
-        countryCities[c.name] = c.cities.map((ci) => ci.name);
-      }
-    } catch {
-      // ignore
+      },
+    });
+    availableCountries = countryData.map((c) => c.name);
+    for (const c of countryData) {
+      countryCities[c.name] = c.cities.map((ci) => ci.name);
     }
-  } else {
-    for (const dj of demoDjs) {
+  } catch {
+    // ignore
+  }
+  if (isStaging) {
+    const demoForCountries = demoDjs.filter((dj) => {
+      const genreOk =
+        genreList.length > 0
+          ? genreList.some((g) =>
+              (dj.genres ?? "").toLowerCase().includes(g.toLowerCase()),
+            )
+          : true;
+      const djTypeOk =
+        djTypeList.length > 0
+          ? (dj.djTypes ?? []).some((t) => djTypeList.includes(t))
+          : true;
+      return genreOk && djTypeOk;
+    });
+    for (const dj of demoForCountries) {
       if (dj.country && !availableCountries.includes(dj.country))
         availableCountries.push(dj.country);
       if (dj.country && dj.city) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,70 +46,77 @@ const Homepage = async () => {
   let dbNewDJs: DemoDJ[] = [];
   let dbTrendingDJs: DemoDJ[] = [];
 
-  if (!isStaging)
-    try {
-      const [recentProfiles, trendingCandidates] = await Promise.all([
-        prisma.djProfile.findMany({
-          where: { deletedAt: null, status: "APPROVED" },
-          orderBy: { createdAt: "desc" },
-          take: 8,
-          include: {
-            user: { include: { _count: { select: { followers: true } } } },
-            country: { select: { name: true } },
-            city: { select: { name: true } },
-            genres: { include: { genre: { select: { name: true } } } },
-            ratings: { select: { rating: true } },
-          },
-        }),
-        prisma.djProfile.findMany({
-          where: { deletedAt: null, status: "APPROVED" },
-          include: {
-            user: { include: { _count: { select: { followers: true } } } },
-            country: { select: { name: true } },
-            city: { select: { name: true } },
-            genres: { include: { genre: { select: { name: true } } } },
-            ratings: { select: { rating: true } },
-          },
-        }),
-      ]);
+  try {
+    const [recentProfiles, trendingCandidates] = await Promise.all([
+      prisma.djProfile.findMany({
+        where: { deletedAt: null, status: "APPROVED" },
+        orderBy: { createdAt: "desc" },
+        take: 8,
+        include: {
+          user: { include: { _count: { select: { followers: true } } } },
+          country: { select: { name: true } },
+          city: { select: { name: true } },
+          genres: { include: { genre: { select: { name: true } } } },
+          ratings: { select: { rating: true } },
+        },
+      }),
+      prisma.djProfile.findMany({
+        where: { deletedAt: null, status: "APPROVED" },
+        include: {
+          user: { include: { _count: { select: { followers: true } } } },
+          country: { select: { name: true } },
+          city: { select: { name: true } },
+          genres: { include: { genre: { select: { name: true } } } },
+          ratings: { select: { rating: true } },
+        },
+      }),
+    ]);
 
-      const toHomeDJ = (p: (typeof recentProfiles)[number]): DemoDJ => ({
-        id: String(p.id),
-        stageName: p.stageName,
-        avatar: p.avatar ?? "/noAvatar.png",
-        genres: p.genres.map((g) => g.genre.name),
-        city: p.city?.name ?? "",
-        country: p.country?.name ?? "",
-        rating:
-          p.ratings.length > 0
-            ? Math.round(
-                (p.ratings.reduce((sum, r) => sum + r.rating, 0) /
-                  p.ratings.length) *
-                  10,
-              ) / 10
-            : 0,
-        followers: p.user._count.followers,
-        slug: p.slug,
-        isPremium: p.plan === "PREMIUM",
-      });
+    const toHomeDJ = (p: (typeof recentProfiles)[number]): DemoDJ => ({
+      id: String(p.id),
+      stageName: p.stageName,
+      avatar: p.avatar ?? "/noAvatar.png",
+      genres: p.genres.map((g) => g.genre.name),
+      city: p.city?.name ?? "",
+      country: p.country?.name ?? "",
+      rating:
+        p.ratings.length > 0
+          ? Math.round(
+              (p.ratings.reduce((sum, r) => sum + r.rating, 0) /
+                p.ratings.length) *
+                10,
+            ) / 10
+          : 0,
+      followers: p.user._count.followers,
+      slug: p.slug,
+      isPremium: p.plan === "PREMIUM",
+    });
 
-      dbNewDJs = recentProfiles.map(toHomeDJ);
-      dbTrendingDJs = trendingCandidates
-        .map(toHomeDJ)
-        .sort((a, b) => b.rating - a.rating || b.followers - a.followers)
-        .slice(0, 10);
-    } catch {
-      // DB unavailable — fall through to demo data
-    }
+    dbNewDJs = recentProfiles.map(toHomeDJ);
+    dbTrendingDJs = trendingCandidates
+      .map(toHomeDJ)
+      .sort((a, b) => b.rating - a.rating || b.followers - a.followers)
+      .slice(0, 10);
+  } catch {
+    // DB unavailable — fall through to demo data
+  }
 
+  const dbSlugs = new Set(dbNewDJs.map((d) => d.slug));
   const newDJs = isStaging
-    ? DEMO_NEW_DJS
+    ? [...dbNewDJs, ...DEMO_NEW_DJS.filter((d) => !dbSlugs.has(d.slug))].slice(
+        0,
+        8,
+      )
     : dbNewDJs.length > 0
       ? dbNewDJs
       : DEMO_NEW_DJS;
 
+  const trendingSlugs = new Set(dbTrendingDJs.map((d) => d.slug));
   const trendingSource = isStaging
-    ? DEMO_TRENDING_DJS
+    ? [
+        ...dbTrendingDJs,
+        ...DEMO_TRENDING_DJS.filter((d) => !trendingSlugs.has(d.slug)),
+      ]
     : dbTrendingDJs.length > 0
       ? dbTrendingDJs
       : DEMO_TRENDING_DJS;

--- a/src/components/directory/FilterBottomSheet.tsx
+++ b/src/components/directory/FilterBottomSheet.tsx
@@ -163,7 +163,7 @@ const FilterBottomSheet = ({
           <div
             aria-hidden="true"
             onClick={closeSheet}
-            className={`fixed inset-0 z-40 bg-black/70 backdrop-blur-sm transition-opacity duration-300 ${visible ? "opacity-100" : "opacity-0"}`}
+            className={`fixed inset-0 z-59 bg-black/70 backdrop-blur-sm transition-opacity duration-300 ${visible ? "opacity-100" : "opacity-0"}`}
           />
 
           {/* Sheet */}
@@ -173,7 +173,7 @@ const FilterBottomSheet = ({
             aria-modal="true"
             aria-label="Filter DJs"
             tabIndex={-1}
-            className={`bg-h_blackLight fixed right-0 bottom-0 left-0 z-50 flex max-h-[90dvh] flex-col rounded-t-2xl border-t border-gray-800 shadow-2xl transition-transform duration-300 ease-out outline-none ${visible ? "translate-y-0" : "translate-y-full"}`}
+            className={`bg-h_blackLight fixed right-0 bottom-0 left-0 z-60 flex max-h-[90dvh] flex-col rounded-t-2xl border-t border-gray-800 shadow-2xl transition-transform duration-300 ease-out outline-none ${visible ? "translate-y-0" : "translate-y-full"}`}
           >
             {/* Drag handle + header */}
             <div className="relative flex shrink-0 items-center justify-between border-b border-gray-800 px-5 pt-5 pb-4">


### PR DESCRIPTION
…d improve filter availability logic

- Remove isStaging conditional wrapping around database queries in directory and homepage
- Always fetch from database and merge with demo data in staging environment
- Deduplicate merged results using Set-based ID/slug filtering
- Update directory filter availability queries to respect active genre/djType/country/city filters
- Filter demo data for genre/country availability based on active filters before merging
- Increase FilterBottomSheet overlay and