### PR TITLE
refactor: replace toLocaleString with formatNumber utility and fix or…

### DIFF
--- a/src/app/dashboard/dj/gigs/[gigId]/page.tsx
+++ b/src/app/dashboard/dj/gigs/[gigId]/page.tsx
@@ -18,6 +18,7 @@ import { GigStatusBadge } from "@/components/gigs/GigStatusBadge";
 import { GigApplicationButton } from "@/components/gigs/GigApplicationButton";
 import { GIG_TYPE_FIELDS } from "@/config/gig-type-fields";
 import { formatDuration } from "@/lib/utils/duration";
+import { formatNumber } from "@/lib/utils/currency";
 
 export default async function DjGigDetailPage({
   params,
@@ -58,9 +59,9 @@ export default async function DjGigDetailPage({
       : gig.budgetType === "NEGOTIABLE"
         ? "Negotiable"
         : gig.budgetType === "FIXED" && gig.budgetMin != null
-          ? `${gig.currency} ${gig.budgetMin.toLocaleString()}`
+          ? `${gig.currency} ${formatNumber(gig.budgetMin)}`
           : gig.budgetMin != null && gig.budgetMax != null
-            ? `${gig.currency} ${gig.budgetMin.toLocaleString()} – ${gig.budgetMax.toLocaleString()}`
+            ? `${gig.currency} ${formatNumber(gig.budgetMin)} – ${formatNumber(gig.budgetMax)}`
             : "Budget TBA";
 
   const canApply =

--- a/src/app/dashboard/organizer/gigs/[gigId]/page.tsx
+++ b/src/app/dashboard/organizer/gigs/[gigId]/page.tsx
@@ -16,6 +16,7 @@ import { GigStatusBadge } from "@/components/gigs/GigStatusBadge";
 import { GigActions } from "@/components/gigs/GigActions";
 import { GIG_TYPE_FIELDS } from "@/config/gig-type-fields";
 import { formatDuration } from "@/lib/utils/duration";
+import { formatNumber } from "@/lib/utils/currency";
 
 export default async function OrganizerGigDetailPage({
   params,
@@ -66,9 +67,9 @@ export default async function OrganizerGigDetailPage({
       : gig.budgetType === "NEGOTIABLE"
         ? "Negotiable"
         : gig.budgetType === "FIXED" && gig.budgetMin != null
-          ? `${gig.currency} ${gig.budgetMin.toLocaleString()}`
+          ? `${gig.currency} ${formatNumber(gig.budgetMin)}`
           : gig.budgetMin != null && gig.budgetMax != null
-            ? `${gig.currency} ${gig.budgetMin.toLocaleString()} – ${gig.budgetMax.toLocaleString()}`
+            ? `${gig.currency} ${formatNumber(gig.budgetMin)} – ${formatNumber(gig.budgetMax)}`
             : "Budget TBA";
 
   return (

--- a/src/app/organizers/[slug]/page.tsx
+++ b/src/app/organizers/[slug]/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import prisma from "@/lib/client";
+import { formatNumber } from "@/lib/utils/currency";
 import {
   MapPin,
   Globe,
@@ -299,15 +300,15 @@ export default async function OrganizerPublicProfilePage({
                     </div>
                     {gig.budgetType === "FIXED" && gig.budgetMin != null && (
                       <span className="shrink-0 rounded-lg bg-white/8 px-3 py-1 text-sm font-medium text-gray-300">
-                        {gig.currency} {gig.budgetMin.toLocaleString()}
+                        {gig.currency} {formatNumber(gig.budgetMin)}
                       </span>
                     )}
                     {gig.budgetType === "RANGE" &&
                       gig.budgetMin != null &&
                       gig.budgetMax != null && (
                         <span className="shrink-0 rounded-lg bg-white/8 px-3 py-1 text-sm font-medium text-gray-300">
-                          {gig.currency} {gig.budgetMin.toLocaleString()} –{" "}
-                          {gig.budgetMax.toLocaleString()}
+                          {gig.currency} {formatNumber(gig.budgetMin)} –{" "}
+                          {formatNumber(gig.budgetMax)}
                         </span>
                       )}
                   </div>

--- a/src/app/sign-up/[[...sign-up]]/SignUpForm.tsx
+++ b/src/app/sign-up/[[...sign-up]]/SignUpForm.tsx
@@ -26,7 +26,7 @@ function SignUpSubmitBtn({ label }: { label: string }) {
   );
 }
 
-type Role = "" | "dj" | "organiser";
+type Role = "" | "dj" | "organizer";
 
 const ROLES: {
   value: Role;
@@ -47,7 +47,7 @@ const ROLES: {
     description: "Create a profile, get discovered & booked",
   },
   {
-    value: "organiser",
+    value: "organizer",
     label: "Organizer",
     icon: "🎪",
     description: "Post gigs, hire DJs & manage events",
@@ -134,7 +134,7 @@ export default function SignUpForm({
         label={
           selected === "dj"
             ? "Sign Up as DJ"
-            : selected === "organiser"
+            : selected === "organizer"
               ? "Sign Up as Organizer"
               : "Sign Up as Fan"
         }

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -7,7 +7,7 @@ export default async function Page({
 }) {
   const { error, role } = await searchParams;
   const defaultRole =
-    role === "dj" ? "dj" : role === "organiser" ? "organiser" : undefined;
+    role === "dj" ? "dj" : role === "organizer" ? "organizer" : undefined;
 
   return (
     <div className="flex min-h-[calc(100vh-96px)] items-center justify-center px-4">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,24 +11,20 @@ import {
 } from "@fortawesome/free-brands-svg-icons";
 import { House, Mic, Mail } from "lucide-react";
 import { getNavUser } from "@/lib/auth/getNavUser";
-import { desktopNavByRole } from "@/config/navigation";
+import {
+  desktopNavByRole,
+  getFooterProfessionalLabel,
+  getFooterProfessionalLinks,
+  type NavRole,
+} from "@/config/navigation";
 
-const footerLinks = {
-  forDJs: [
-    { label: "Join as DJ", href: "/sign-up?role=dj" },
-    { label: "Join as Organiser", href: "/sign-up?role=organiser" },
-    { label: "Create Your Profile", href: "/sign-up?role=dj" },
-    { label: "Browse DJ Events", href: "/community" },
-    { label: "DJ Resources", href: "/directory" },
-  ],
-  company: [
-    { label: "About DJscovery", href: "/" },
-    { label: "Contact Us", href: "/" },
-    { label: "Privacy Policy", href: "/" },
-    { label: "Terms of Service", href: "/" },
-    { label: "Cookie Policy", href: "/" },
-  ],
-};
+const companyLinks = [
+  { label: "About DJscovery", href: "/" },
+  { label: "Contact Us", href: "/" },
+  { label: "Privacy Policy", href: "/" },
+  { label: "Terms of Service", href: "/" },
+  { label: "Cookie Policy", href: "/" },
+];
 
 const socialLinks = [
   { icon: faXTwitter, href: "#", label: "X (Twitter)" },
@@ -39,16 +35,34 @@ const socialLinks = [
 ];
 
 const Footer = async () => {
-  let navRole: keyof typeof desktopNavByRole = "guest";
+  let navData: {
+    navRole: NavRole;
+    djSlug: string | null;
+    organizerSlug: string | null;
+    isOrganizer: boolean;
+  } = {
+    navRole: "guest",
+    djSlug: null,
+    organizerSlug: null,
+    isOrganizer: false,
+  };
   try {
-    ({ navRole } = await getNavUser());
+    const user = await getNavUser();
+    navData = {
+      navRole: user.navRole,
+      djSlug: user.djSlug,
+      organizerSlug: user.organizerSlug,
+      isOrganizer: user.isOrganizer,
+    };
   } catch {
-    navRole = "guest";
+    // keep guest defaults
   }
   const exploreItems = [
     { id: "home", label: "Home", href: "/", icon: House },
-    ...desktopNavByRole[navRole],
+    ...desktopNavByRole[navData.navRole],
   ];
+  const professionalLinks = getFooterProfessionalLinks(navData);
+  const professionalLabel = getFooterProfessionalLabel(navData.navRole);
   return (
     <footer className="w-full border-t border-white/5 bg-black">
       {/* Top accent bar */}
@@ -169,13 +183,13 @@ const Footer = async () => {
               </ul>
             </div>
 
-            {/* ── For DJs & Organisers ── */}
+            {/* ── For DJs & Organizers ── */}
             <div className="flex flex-col gap-4">
               <h4 className="text-xs font-semibold tracking-[0.15em] text-white uppercase">
-                For DJs &amp; Organisers
+                {professionalLabel}
               </h4>
               <ul className="flex flex-col gap-3">
-                {footerLinks.forDJs.map((link) => (
+                {professionalLinks.map((link) => (
                   <li key={link.label}>
                     <Link
                       href={link.href}
@@ -195,7 +209,7 @@ const Footer = async () => {
                 Company
               </h4>
               <ul className="flex flex-col gap-3">
-                {footerLinks.company.map((link) => (
+                {companyLinks.map((link) => (
                   <li key={link.label}>
                     <Link
                       href={link.href}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -19,7 +19,7 @@ const Hero = async () => {
     : null;
 
   const djHref = user ? "/become-dj" : "/sign-up?role=dj";
-  const organiserHref = user ? "/become-organizer" : "/sign-up?role=organiser";
+  const organizerHref = user ? "/become-organizer" : "/sign-up?role=organizer";
   return (
     <>
       <section className="relative h-[60vh] w-full bg-zinc-800 md:h-[50vh] lg:h-[55vh]">
@@ -105,7 +105,7 @@ const Hero = async () => {
                     variant="outline"
                     className="border-h_red hover:bg-h_red h-auto px-6 py-3 text-sm font-semibold text-red-300 hover:text-white md:text-base"
                   >
-                    <Link href={organiserHref}>Join as Organiser</Link>
+                    <Link href={organizerHref}>Join as Organizer</Link>
                   </Button>
                 </>
               )}

--- a/src/components/directory/DjCard.tsx
+++ b/src/components/directory/DjCard.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCrown } from "@fortawesome/free-solid-svg-icons";
 import { CircleCheck } from "lucide-react";
 import { DjUser } from "@/lib/data";
+import { formatNumber } from "@/lib/utils/currency";
 
 const DjCard = ({
   username,
@@ -34,10 +35,10 @@ const DjCard = ({
   };
 
   return (
-    <div className="bg-h_blackLight/50 rounded-xl p-4 flex flex-col gap-3 hover:ring-1 hover:ring-h_red hover:scale-[1.015] hover:shadow-lg hover:shadow-h_red/5 transition-all duration-200 relative group">
+    <div className="bg-h_blackLight/50 hover:ring-h_red hover:shadow-h_red/5 group relative flex flex-col gap-3 rounded-xl p-4 transition-all duration-200 hover:scale-[1.015] hover:shadow-lg hover:ring-1">
       <Link
         href={profileHref}
-        className="flex items-center gap-3 outline-none focus-visible:ring-2 focus-visible:ring-h_red focus-visible:rounded-lg"
+        className="focus-visible:ring-h_red flex items-center gap-3 outline-none focus-visible:rounded-lg focus-visible:ring-2"
       >
         <div className="relative shrink-0">
           <Image
@@ -45,10 +46,10 @@ const DjCard = ({
             alt={stageName || username}
             width={56}
             height={56}
-            className="w-14 h-14 object-cover rounded-full ring-2 ring-h_red"
+            className="ring-h_red h-14 w-14 rounded-full object-cover ring-2"
           />
           {isPremium && (
-            <div className="absolute -bottom-1 -right-1 size-5 rounded-full bg-amber-400 border-2 border-black flex items-center justify-center">
+            <div className="absolute -right-1 -bottom-1 flex size-5 items-center justify-center rounded-full border-2 border-black bg-amber-400">
               <FontAwesomeIcon
                 icon={faCrown}
                 className="h-2.5 w-2.5 text-black"
@@ -58,21 +59,21 @@ const DjCard = ({
         </div>
         <div className="min-w-0">
           <div className="flex items-center gap-1.5">
-            <h3 className="text-h_white font-semibold text-sm truncate">
+            <h3 className="text-h_white truncate text-sm font-semibold">
               {formatDjName(stageName || username)}
             </h3>
             {verified && (
-              <CircleCheck className="h-3.5 w-3.5 text-blue-400 shrink-0" />
+              <CircleCheck className="h-3.5 w-3.5 shrink-0 text-blue-400" />
             )}
           </div>
           {(city || country) && (
-            <p className="text-gray-400 text-xs truncate">
+            <p className="truncate text-xs text-gray-400">
               {[city, country].filter(Boolean).join(", ")}
             </p>
           )}
           {_count !== undefined && (
-            <p className="text-gray-500 text-xs">
-              {_count.followers.toLocaleString()} followers
+            <p className="text-xs text-gray-500">
+              {formatNumber(_count.followers)} followers
             </p>
           )}
         </div>
@@ -83,7 +84,7 @@ const DjCard = ({
           {genreList.slice(0, 3).map((genre) => (
             <span
               key={genre}
-              className="text-xs bg-h_redDark/60 text-red-200 px-2 py-0.5 rounded-full"
+              className="bg-h_redDark/60 rounded-full px-2 py-0.5 text-xs text-red-200"
             >
               {genre}
             </span>
@@ -93,7 +94,7 @@ const DjCard = ({
 
       <Link
         href={profileHref}
-        className="mt-auto bg-h_red hover:bg-h_redDark active:scale-95 text-white text-xs px-3 py-1.5 rounded-md w-full transition-all text-center cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-h_red"
+        className="bg-h_red hover:bg-h_redDark focus-visible:ring-h_red mt-auto w-full cursor-pointer rounded-md px-3 py-1.5 text-center text-xs text-white transition-all outline-none focus-visible:ring-2 focus-visible:ring-offset-1 active:scale-95"
       >
         View Profile
       </Link>

--- a/src/components/dj-profile/DjProfileFree.tsx
+++ b/src/components/dj-profile/DjProfileFree.tsx
@@ -9,6 +9,7 @@ import { Card } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
+import { formatNumber } from "@/lib/utils/currency";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   MapPin,
@@ -256,7 +257,7 @@ export default function DjProfileFree({
           <div className="grid grid-cols-3 py-5">
             {[
               {
-                val: DJ.followerCount.toLocaleString(),
+                val: formatNumber(DJ.followerCount),
                 label: "Followers",
                 icon: Users,
               },

--- a/src/components/dj-profile/DjProfilePremium.tsx
+++ b/src/components/dj-profile/DjProfilePremium.tsx
@@ -9,6 +9,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Progress } from "@/components/ui/progress";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
+import { formatNumber } from "@/lib/utils/currency";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   MapPin,
@@ -270,7 +271,7 @@ export default function DjProfilePremium({
           <div className="grid grid-cols-3 divide-x divide-white/10 py-5 md:grid-cols-6">
             {[
               {
-                val: DJ.followerCount.toLocaleString(),
+                val: formatNumber(DJ.followerCount),
                 label: "Followers",
                 icon: Users,
               },
@@ -298,7 +299,7 @@ export default function DjProfilePremium({
                 green: true,
               },
               {
-                val: DJ.profileViews.toLocaleString(),
+                val: formatNumber(DJ.profileViews),
                 label: "Monthly Views",
                 icon: Eye,
               },

--- a/src/components/gigs/GigCard.tsx
+++ b/src/components/gigs/GigCard.tsx
@@ -6,6 +6,7 @@ import { GIG_TYPE_FIELDS } from "@/config/gig-type-fields";
 import type { OrganizerGigListItem } from "@/lib/queries/gigs";
 import type { DjGigListItem } from "@/lib/queries/gigs";
 import type { BudgetType } from "@prisma/client";
+import { formatNumber } from "@/lib/utils/currency";
 
 // ─── Budget formatter ─────────────────────────────────────────────────────────
 
@@ -18,9 +19,9 @@ function formatBudget(
   if (budgetType === "NEGOTIABLE") return "Negotiable";
   if (budgetType === "TBA") return "Budget TBA";
   if (budgetType === "FIXED" && budgetMin != null)
-    return `${currency} ${budgetMin.toLocaleString()}`;
+    return `${currency} ${formatNumber(budgetMin)}`;
   if (budgetType === "RANGE" && budgetMin != null && budgetMax != null)
-    return `${currency} ${budgetMin.toLocaleString()} – ${budgetMax.toLocaleString()}`;
+    return `${currency} ${formatNumber(budgetMin)} – ${formatNumber(budgetMax)}`;
   return "Budget TBA";
 }
 

--- a/src/components/home/HomeCommunityHighlights.tsx
+++ b/src/components/home/HomeCommunityHighlights.tsx
@@ -4,6 +4,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import prisma from "@/lib/client";
 import { formatDistanceToNow } from "date-fns";
+import { formatNumber } from "@/lib/utils/currency";
 
 type PostCard = {
   id: number | string;
@@ -160,7 +161,7 @@ export default async function HomeCommunityHighlights() {
                 </p>
 
                 <div className="mt-auto flex items-center gap-4 border-t border-white/5 pt-3 text-xs text-gray-500">
-                  <span>❤️ {post.likes.toLocaleString()} likes</span>
+                  <span>❤️ {formatNumber(post.likes)} likes</span>
                   <span>💬 {post.comments} comments</span>
                 </div>
               </Card>

--- a/src/components/home/HomeCtaBanner.tsx
+++ b/src/components/home/HomeCtaBanner.tsx
@@ -17,7 +17,7 @@ export default async function HomeCtaBanner() {
   if (hasUpgradeableRole) return null;
 
   const djHref = user ? "/become-dj" : "/sign-up?role=dj";
-  const organiserHref = user ? "/become-organizer" : "/sign-up?role=organiser";
+  const organizerHref = user ? "/become-organizer" : "/sign-up?role=organizer";
   return (
     <section className="border-t border-white/5 px-4 py-16 md:px-8">
       <div className="mx-auto max-w-7xl">
@@ -48,7 +48,7 @@ export default async function HomeCtaBanner() {
                   I&apos;m a DJ
                 </h3>
                 <p className="mt-1 text-sm leading-relaxed text-gray-400">
-                  Showcase your mixes, get discovered by organisers, and grow
+                  Showcase your mixes, get discovered by organizers, and grow
                   your fanbase.
                 </p>
               </div>
@@ -65,12 +65,12 @@ export default async function HomeCtaBanner() {
               </Button>
             </div>
 
-            {/* Organiser card */}
+            {/* Organizer card */}
             <div className="flex flex-col gap-4 rounded-xl border border-white/10 bg-black/40 p-6">
               <div className="text-4xl">🎪</div>
               <div>
                 <h3 className="text-xl font-semibold text-white">
-                  I&apos;m an Organiser
+                  I&apos;m an Organizer
                 </h3>
                 <p className="mt-1 text-sm leading-relaxed text-gray-400">
                   Find and book the perfect DJ for your event from a global
@@ -87,7 +87,7 @@ export default async function HomeCtaBanner() {
                 variant="outline"
                 className="border-h_red hover:bg-h_red mt-auto w-full cursor-pointer font-semibold text-red-200 hover:text-white"
               >
-                <Link href={organiserHref}>Join as Organiser</Link>
+                <Link href={organizerHref}>Join as Organizer</Link>
               </Button>
             </div>
           </div>

--- a/src/components/home/HomeDJsRow.tsx
+++ b/src/components/home/HomeDJsRow.tsx
@@ -4,6 +4,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import { formatNumber } from "@/lib/utils/currency";
 
 export type DemoDJ = {
   id: number | string;
@@ -102,7 +103,7 @@ export default function HomeDJsRow({
 
                   <div className="mt-auto flex items-center justify-between border-t border-white/5 pt-2 text-xs text-gray-400">
                     <span>⭐ {dj.rating}</span>
-                    <span>{dj.followers.toLocaleString()} fans</span>
+                    <span>{formatNumber(dj.followers)} fans</span>
                   </div>
                 </Card>
               </Link>

--- a/src/components/home/HomeDJsTabs.tsx
+++ b/src/components/home/HomeDJsTabs.tsx
@@ -8,6 +8,7 @@ import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { formatNumber } from "@/lib/utils/currency";
 import { Card } from "@/components/ui/card";
 import type { DemoDJ } from "./HomeDJsRow";
 
@@ -145,7 +146,7 @@ function DJCard({
 
         <div className="mt-auto flex items-center justify-between border-t border-white/5 pt-2 text-xs text-gray-400">
           <span>⭐ {dj.rating}</span>
-          <span>{dj.followers.toLocaleString()} fans</span>
+          <span>{formatNumber(dj.followers)} fans</span>
         </div>
       </Card>
     </Link>

--- a/src/components/home/HomeFeaturedDJs.tsx
+++ b/src/components/home/HomeFeaturedDJs.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCrown } from "@fortawesome/free-solid-svg-icons";
 import { PREMIUM_DEMO_DJS } from "@/data/djs";
+import { formatNumber } from "@/lib/utils/currency";
 
 const FEATURED_DJS = [...PREMIUM_DEMO_DJS]
   .sort(
@@ -101,7 +102,7 @@ export default function HomeFeaturedDJs() {
 
                   <div className="mt-auto flex items-center justify-between border-t border-white/5 pt-3 text-xs text-gray-400">
                     <span>⭐ {dj.rating} rating</span>
-                    <span>{dj.followers.toLocaleString()} followers</span>
+                    <span>{formatNumber(dj.followers)} followers</span>
                   </div>
                 </div>
               </Card>

--- a/src/components/home/HomeOpenGigsSection.tsx
+++ b/src/components/home/HomeOpenGigsSection.tsx
@@ -57,7 +57,7 @@ export default function HomeOpenGigsSection() {
               Open Gigs
             </h2>
             <p className="mt-1 text-sm leading-relaxed text-gray-400">
-              Organisers looking to hire right now
+              Organizers looking to hire right now
             </p>
           </div>
           <Button

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -1,12 +1,5 @@
 import type { LucideIcon } from "lucide-react";
-import {
-  Home,
-  Headphones,
-  Briefcase,
-  CalendarDays,
-  Users,
-  User,
-} from "lucide-react";
+import { Home, Headphones, Briefcase, CalendarDays, User } from "lucide-react";
 
 export type NavRole = "guest" | "fan" | "dj" | "organizer" | "admin";
 
@@ -49,13 +42,6 @@ const events: NavItem = {
   comingSoon: true,
 };
 
-const community: NavItem = {
-  id: "community",
-  label: "Community",
-  href: "/community",
-  icon: Users,
-};
-
 const profile: NavItem = {
   id: "profile",
   label: "Profile",
@@ -71,11 +57,11 @@ const account: NavItem = {
 };
 
 export const desktopNavByRole: Record<NavRole, NavItem[]> = {
-  guest: [directory, events, community],
-  fan: [directory, events, community],
-  dj: [directory, djGigs, events, community],
-  organizer: [directory, orgGigs, events, community],
-  admin: [directory, djGigs, events, community],
+  guest: [directory, events],
+  fan: [directory, events],
+  dj: [directory, djGigs, events],
+  organizer: [directory, orgGigs, events],
+  admin: [directory, djGigs, events],
 };
 
 export const bottomNavByRole: Record<NavRole, NavItem[]> = {
@@ -85,3 +71,68 @@ export const bottomNavByRole: Record<NavRole, NavItem[]> = {
   organizer: [home, directory, orgGigs, events, profile],
   admin: [home, directory, djGigs, events, profile],
 };
+
+export type FooterProfessionalLink = {
+  label: string;
+  href: string;
+};
+
+export function getFooterProfessionalLabel(navRole: NavRole): string {
+  if (navRole === "dj" || navRole === "admin") return "DJ Hub";
+  if (navRole === "organizer") return "Organizer Hub";
+  if (navRole === "fan") return "Go Professional";
+  return "For DJs & Organizers";
+}
+
+export function getFooterProfessionalLinks(opts: {
+  navRole: NavRole;
+  djSlug: string | null;
+  organizerSlug: string | null;
+  isOrganizer: boolean;
+}): FooterProfessionalLink[] {
+  const { navRole, djSlug, organizerSlug, isOrganizer } = opts;
+
+  if (navRole === "dj" || navRole === "admin") {
+    return [
+      ...(djSlug ? [{ label: "My DJ Profile", href: `/djs/${djSlug}` }] : []),
+      { label: "My Gigs", href: "/dashboard/dj/gigs" },
+      { label: "Applications", href: "/dashboard/dj/applications" },
+      { label: "Account Settings", href: "/settings" },
+      ...(!isOrganizer
+        ? [{ label: "Become an Organizer", href: "/become-organizer" }]
+        : [{ label: "Organizer Dashboard", href: "/organizer/dashboard" }]),
+    ];
+  }
+
+  if (navRole === "organizer") {
+    return [
+      ...(organizerSlug
+        ? [
+            {
+              label: "My Organizer Profile",
+              href: `/organizers/${organizerSlug}`,
+            },
+          ]
+        : []),
+      { label: "Organizer Dashboard", href: "/organizer/dashboard" },
+      { label: "Post a Gig", href: "/dashboard/organizer/gigs/new" },
+      { label: "My Gigs", href: "/dashboard/organizer/gigs" },
+      { label: "Become a DJ", href: "/become-dj" },
+    ];
+  }
+
+  if (navRole === "fan") {
+    return [
+      { label: "Become a DJ", href: "/become-dj" },
+      { label: "Become an Organizer", href: "/become-organizer" },
+      { label: "Browse DJ Directory", href: "/directory" },
+    ];
+  }
+
+  return [
+    { label: "Join as DJ", href: "/sign-up?role=dj" },
+    { label: "Join as Organizer", href: "/sign-up?role=organizer" },
+    { label: "Create Your Profile", href: "/sign-up?role=dj" },
+    { label: "Browse DJ Directory", href: "/directory" },
+  ];
+}

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -41,7 +41,7 @@ export async function signUp(formData: FormData) {
 
     // Skip select-role — user already chose their role on the sign-up form
     if (role === "dj") redirect("/become-dj");
-    if (role === "organiser") redirect("/become-organizer");
+    if (role === "organizer") redirect("/become-organizer");
     redirect("/"); // Fan — go straight to the app
   }
 
@@ -49,7 +49,7 @@ export async function signUp(formData: FormData) {
   const next =
     role === "dj"
       ? "/become-dj"
-      : role === "organiser"
+      : role === "organizer"
         ? "/become-organizer"
         : "/";
   redirect(

--- a/src/lib/dj-profile-mappers.ts
+++ b/src/lib/dj-profile-mappers.ts
@@ -1,4 +1,5 @@
 import type { DjDemoData } from "@/types/dj-demo";
+import { formatNumber } from "@/lib/utils/currency";
 import { Newspaper } from "lucide-react";
 import {
   REVIEWER_AVATARS,
@@ -35,8 +36,8 @@ export function mapFreeDjToProps(d: DjDemoData) {
     bookingEmail: d.booking.email,
     bookingPhone: d.booking.phone,
     website: d.booking.website,
-    minFee: `${d.booking.feeRange.currency}${d.booking.feeRange.min.toLocaleString()}`,
-    maxFee: `${d.booking.feeRange.currency}${d.booking.feeRange.max.toLocaleString()}`,
+    minFee: `${d.booking.feeRange.currency}${formatNumber(d.booking.feeRange.min)}`,
+    maxFee: `${d.booking.feeRange.currency}${formatNumber(d.booking.feeRange.max)}`,
     djTypes: d.specialties,
   };
 }
@@ -117,8 +118,8 @@ export function mapPremiumDjToProps(d: DjDemoData) {
     bookingEmail: d.booking.email,
     bookingPhone: d.booking.phone,
     website: d.booking.website,
-    minFee: `${d.booking.feeRange.currency}${d.booking.feeRange.min.toLocaleString()}`,
-    maxFee: `${d.booking.feeRange.currency}${d.booking.feeRange.max.toLocaleString()}`,
+    minFee: `${d.booking.feeRange.currency}${formatNumber(d.booking.feeRange.min)}`,
+    maxFee: `${d.booking.feeRange.currency}${formatNumber(d.booking.feeRange.max)}`,
     djTypes: d.specialties,
     manager: {
       name: d.team.manager.name,
@@ -222,7 +223,7 @@ export function mapPackagesFromData(d: DjDemoData) {
     name: pkg.name,
     icon:
       PACKAGE_ICON_MAP[pkg.name] ?? HIGHLIGHT_ICONS[i % HIGHLIGHT_ICONS.length],
-    price: `From ${pkg.currency}${pkg.priceFrom.toLocaleString()}`,
+    price: `From ${pkg.currency}${formatNumber(pkg.priceFrom)}`,
     duration: pkg.features[0] ?? "",
     includes: pkg.features.slice(1),
     color: PKG_COLORS[pkg.name] ?? "from-h_red/20 to-transparent",

--- a/src/lib/utils/currency.ts
+++ b/src/lib/utils/currency.ts
@@ -49,7 +49,14 @@ export const COUNTRY_CURRENCY_MAP: Record<string, string> = {
   PK: "PKR",
 };
 
-export function currencyForCountryCode(code: string | null | undefined): string {
+export function currencyForCountryCode(
+  code: string | null | undefined,
+): string {
   if (!code) return "SEK";
   return COUNTRY_CURRENCY_MAP[code.toUpperCase()] ?? "SEK";
+}
+
+/** Always use en-US locale to prevent server/client hydration mismatches */
+export function formatNumber(n: number): string {
+  return new Intl.NumberFormat("en-US").format(n);
 }


### PR DESCRIPTION
…ganiser/organizer typo

- Replace all toLocaleString() calls with formatNumber utility from lib/utils/currency
- Update budget display in DJ and organizer gig detail pages to use formatNumber
- Update follower counts, profile views, and likes display across DJ profiles and community highlights
- Fix inconsistent spelling of "organiser" to "organizer" throughout codebase (SignUpForm, Hero, Footer, HomeCtaBanner)
- Add formatNumber import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized number formatting across budgets, follower counts, and pricing displays for improved consistency.

* **Bug Fixes**
  * Corrected spelling of "Organizer" throughout the app.
  * Fixed organizer-related routing and navigation references.

* **Style**
  * Updated footer link organization for better navigation structure.
  * Refined profile card and component styling for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->