### PR TITLE
refactor: add "Dj." prefix to stage names across home page components…

### DIFF
--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -102,7 +102,7 @@ export function EventCard({ event }: { event: EventCardItem }) {
           )}
           {event.djName && (
             <Badge className="bg-h_redDark/60 mt-1 w-fit border-0 text-red-300">
-              🎧 DJ. {event.djName}
+              🎧 Dj. {event.djName}
             </Badge>
           )}
         </div>

--- a/src/components/home/HomeDJsRow.tsx
+++ b/src/components/home/HomeDJsRow.tsx
@@ -82,7 +82,7 @@ export default function HomeDJsRow({
                     </Avatar>
                     <div>
                       <p className="mx-auto w-40 truncate text-sm leading-tight font-semibold text-white">
-                        {dj.stageName}
+                        Dj. {dj.stageName}
                       </p>
                       <p className="mt-0.5 text-xs text-gray-500">
                         📍 {dj.city}, {dj.country}

--- a/src/components/home/HomeDJsTabs.tsx
+++ b/src/components/home/HomeDJsTabs.tsx
@@ -149,7 +149,7 @@ function DJCard({
           </div>
           <div>
             <p className="mx-auto w-40 truncate text-sm leading-tight font-semibold text-white">
-              {dj.stageName}
+              Dj. {dj.stageName}
             </p>
             <p className="mt-0.5 text-xs text-gray-500">
               📍 {dj.city}, {dj.country}

--- a/src/components/home/HomeFeaturedDJs.tsx
+++ b/src/components/home/HomeFeaturedDJs.tsx
@@ -51,8 +51,8 @@ export default function HomeFeaturedDJs() {
 
         <div className="grid grid-cols-1 gap-5 md:grid-cols-3">
           {FEATURED_DJS.map((dj) => (
-            <Link key={dj.slug} href={`/djs/${dj.slug}`}>
-              <Card className="bg-h_blackLight/50 hover:ring-h_red gap-0 overflow-hidden p-0 ring-white/5 transition-all">
+            <Link key={dj.slug} href={`/djs/${dj.slug}`} className="h-full">
+              <Card className="bg-h_blackLight/50 hover:ring-h_red flex h-full flex-col gap-0 overflow-hidden p-0 ring-white/5 transition-all">
                 <div className="from-h_cyanDark relative h-24 bg-linear-to-r to-black">
                   <div className="absolute -bottom-8 left-4">
                     <div className="relative">
@@ -75,10 +75,10 @@ export default function HomeFeaturedDJs() {
                   </Badge>
                 </div>
 
-                <div className="flex flex-col gap-3 px-4 pt-10 pb-4">
+                <div className="flex flex-1 flex-col gap-3 px-4 pt-10 pb-4">
                   <div>
                     <p className="text-lg leading-tight font-bold text-white">
-                      {dj.stageName}
+                      Dj. {dj.stageName}
                     </p>
                     <p className="mt-0.5 text-xs text-gray-500">
                       📍 {dj.city}, {dj.country}


### PR DESCRIPTION
… and fix featured DJ card layout

- Add "Dj." prefix to stage names in HomeDJsRow, HomeDJsTabs, and HomeFeaturedDJs components
- Change "DJ." to "Dj." in EventCard badge for consistency
- Make featured DJ cards full height with flex layout to ensure equal card heights
- Move Link wrapper to parent of Card in HomeFeaturedDJs to enable full-height clickable area
- Add flex-1 to card content container to push footer content to bottom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized DJ name displays across event cards and home page components to consistently include "Dj." prefix before stage names.
  * Adjusted spacing and layout styling for featured DJ cards for improved visual hierarchy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->