### PR TITLE
refactor: enable RLS for EventMedia, Gig, and GigApplication tables a…

### DIFF
--- a/docs/rls-policies.sql
+++ b/docs/rls-policies.sql
@@ -43,6 +43,9 @@ ALTER TABLE "Message"                 ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "EventAttendance"         ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "Hire"                    ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "OrganizerSocialLink"     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "EventMedia"              ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Gig"                     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "GigApplication"          ENABLE ROW LEVEL SECURITY;
 
 
 -- ============================================================
@@ -330,6 +333,69 @@ CREATE POLICY "Organizer can delete own social links"
       WHERE "userId" = auth.uid()::text AND role = 'ORGANIZER'
     )
   );
+
+-- ============================================================
+-- STEP 9 (cont): Gig & GigApplication RLS
+-- ============================================================
+
+CREATE POLICY "Public read published gigs"
+  ON "Gig" FOR SELECT
+  USING (status = 'PUBLISHED' AND "deletedAt" IS NULL);
+
+CREATE POLICY "Organizer can read own gigs"
+  ON "Gig" FOR SELECT
+  USING (
+    "organizerProfileId" IN (
+      SELECT id FROM "OrganizerProfile" WHERE "userId" = auth.uid()::text
+    )
+  );
+
+CREATE POLICY "Public read event media for published events"
+  ON "EventMedia" FOR SELECT
+  USING (
+    "eventId" IN (
+      SELECT id FROM "Event"
+      WHERE status = 'PUBLISHED' AND "deletedAt" IS NULL
+    )
+  );
+
+CREATE POLICY "DJ can read own gig applications"
+  ON "GigApplication" FOR SELECT
+  USING (
+    "djProfileId" IN (
+      SELECT id FROM "DjProfile" WHERE "userId" = auth.uid()::text
+    )
+  );
+
+CREATE POLICY "Organizer can read applications for own gigs"
+  ON "GigApplication" FOR SELECT
+  USING (
+    "gigId" IN (
+      SELECT g.id FROM "Gig" g
+      JOIN "OrganizerProfile" op ON g."organizerProfileId" = op.id
+      WHERE op."userId" = auth.uid()::text
+    )
+  );
+
+CREATE POLICY "DJ can apply to gigs"
+  ON "GigApplication" FOR INSERT
+  WITH CHECK (
+    "djProfileId" IN (
+      SELECT id FROM "DjProfile" WHERE "userId" = auth.uid()::text
+    )
+    AND EXISTS (
+      SELECT 1 FROM "UserRole" WHERE "userId" = auth.uid()::text AND role = 'DJ'
+    )
+  );
+
+CREATE POLICY "DJ can withdraw own application"
+  ON "GigApplication" FOR DELETE
+  USING (
+    "djProfileId" IN (
+      SELECT id FROM "DjProfile" WHERE "userId" = auth.uid()::text
+    )
+  );
+
 
 -- JobApplication: applicant reads own records.
 -- Organizer access is enforced server-side via Prisma (bypasses RLS) — no policy needed here.

--- a/src/components/navbar/NavDesktop.tsx
+++ b/src/components/navbar/NavDesktop.tsx
@@ -89,7 +89,7 @@ export default function NavDesktop({
               key={item.id}
               href={item.href}
               className={cn(
-                "focus-visible:ring-h_red relative flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all duration-150 focus-visible:ring-2 focus-visible:outline-none",
+                "focus-visible:ring-h_red relative flex items-center gap-1 rounded-lg px-3 py-2 text-sm transition-all duration-150 focus-visible:ring-2 focus-visible:outline-none",
                 isActive
                   ? "text-white"
                   : "text-gray-400 hover:bg-white/5 hover:text-white",


### PR DESCRIPTION
…nd add comprehensive policies

- Enable row level security for EventMedia, Gig, and GigApplication tables
- Add public read policy for published gigs with non-null deletedAt
- Add organizer read policy for own gigs via organizerProfileId
- Add public read policy for event media linked to published events
- Add DJ read policy for own gig applications via djProfileId
- Add organizer read policy for applications to own gigs
- Add DJ insert

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Row-level security policies now govern access to gigs, gig applications, and event media, ensuring users can only view relevant data based on their role.

* **Style**
  * Navigation bar link spacing refined for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->