### PR TITLE
refactor: add table-level SELECT grants for authenticated role to sup…

### DIFF
--- a/docs/rls-policies.sql
+++ b/docs/rls-policies.sql
@@ -66,8 +66,9 @@ GRANT SELECT ON "User"             TO authenticated;
 GRANT SELECT ON "FanProfile"       TO authenticated;
 GRANT SELECT ON "GigApplication"   TO authenticated;
 GRANT SELECT ON "Gig"              TO authenticated;
-GRANT SELECT ON "Event"            TO authenticated;
-GRANT SELECT ON "EventDj"          TO authenticated;
+GRANT SELECT ON "Event"                   TO authenticated;
+GRANT SELECT ON "EventDj"                 TO authenticated;
+GRANT SELECT ON "ConversationParticipant" TO authenticated;
 
 
 -- ============================================================

--- a/docs/rls-policies.sql
+++ b/docs/rls-policies.sql
@@ -52,6 +52,25 @@ ALTER TABLE "SavedEvent"              ENABLE ROW LEVEL SECURITY;
 
 
 -- ============================================================
+-- STEP 1b: Grant table-level SELECT to authenticated role
+-- Required so storage RLS policies can cross-reference these
+-- tables in their WITH CHECK / USING clauses.
+-- Without this GRANT, PostgreSQL throws "permission denied for
+-- table UserRole" before the row-level RLS policy is evaluated.
+-- ============================================================
+
+GRANT SELECT ON "UserRole"         TO authenticated;
+GRANT SELECT ON "DjProfile"        TO authenticated;
+GRANT SELECT ON "OrganizerProfile" TO authenticated;
+GRANT SELECT ON "User"             TO authenticated;
+GRANT SELECT ON "FanProfile"       TO authenticated;
+GRANT SELECT ON "GigApplication"   TO authenticated;
+GRANT SELECT ON "Gig"              TO authenticated;
+GRANT SELECT ON "Event"            TO authenticated;
+GRANT SELECT ON "EventDj"          TO authenticated;
+
+
+-- ============================================================
 -- DROP ALL EXISTING POLICIES (idempotent re-run on any PG version)
 -- ============================================================
 


### PR DESCRIPTION
…port storage RLS policies

- Add GRANT SELECT statements for UserRole, DjProfile, OrganizerProfile, User, FanProfile, GigApplication, Gig, Event, and EventDj tables
- Required to allow storage RLS policies to cross-reference these tables in WITH CHECK/USING clauses
- Prevents "permission denied" errors that occur before row-level policies are evaluated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated database security policies to grant SELECT permissions for authenticated users, preventing permission-denied errors in policy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->