### PR TITLE
refactor: add 5-genre limit to DJ profiles and enable cover image upl…

### DIFF
--- a/src/app/directory/page.tsx
+++ b/src/app/directory/page.tsx
@@ -41,6 +41,7 @@ const DirectoryPage = async ({
     const profiles = await prisma.djProfile.findMany({
       where: {
         deletedAt: null,
+        status: "APPROVED",
         ...(q
           ? {
               OR: [
@@ -184,6 +185,7 @@ const DirectoryPage = async ({
           some: {
             djProfile: {
               deletedAt: null,
+              status: "APPROVED",
               ...(country
                 ? {
                     country: {
@@ -238,6 +240,7 @@ const DirectoryPage = async ({
   try {
     const countryWhere = {
       deletedAt: null as null,
+      status: "APPROVED" as const,
       ...(genreList.length > 0
         ? { genres: { some: { genre: { name: { in: genreList } } } } }
         : {}),

--- a/src/components/BecomeDjForm.tsx
+++ b/src/components/BecomeDjForm.tsx
@@ -164,7 +164,7 @@ export default function BecomeDjForm({
     setSelectedGenreIds((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
-      else next.add(id);
+      else if (next.size < 5) next.add(id);
       return next;
     });
   }
@@ -180,7 +180,9 @@ export default function BecomeDjForm({
           ? prev
           : [...prev, genre].sort((a, b) => a.name.localeCompare(b.name)),
       );
-      setSelectedGenreIds((prev) => new Set([...prev, genre.id]));
+      setSelectedGenreIds((prev) =>
+        prev.size >= 5 ? prev : new Set([...prev, genre.id]),
+      );
       setNewGenreInput("");
     } catch {
       // silently ignore — genre may already exist
@@ -548,11 +550,18 @@ export default function BecomeDjForm({
       <div
         className={`${sectionCls} ${fieldErrors.genres ? "border-red-500/40" : ""}`}
       >
-        <h2 className={sectionTitleCls}>
-          Genres <span className="text-h_red">*</span>
-        </h2>
+        <div className="mb-1 flex items-center justify-between border-b border-white/10 pb-3">
+          <h2 className="text-base font-semibold text-white">
+            Genres <span className="text-h_red">*</span>
+          </h2>
+          <span
+            className={`text-xs font-medium ${selectedGenreIds.size >= 5 ? "text-amber-400" : "text-gray-500"}`}
+          >
+            {selectedGenreIds.size}/5
+          </span>
+        </div>
         <p className="-mt-2 text-xs text-gray-400">
-          Select all genres that apply to your style.
+          Select up to 5 genres that apply to your style.
         </p>
 
         <div className="flex flex-wrap gap-2">
@@ -591,14 +600,21 @@ export default function BecomeDjForm({
                 handleAddGenre();
               }
             }}
-            placeholder='Not in the list? Add it as "Other" e.g. Cumbia...'
+            placeholder={
+              selectedGenreIds.size >= 5
+                ? "Max 5 genres reached"
+                : "Not in the list? Add e.g. Cumbia..."
+            }
             maxLength={50}
-            className="focus:ring-h_red flex-1 rounded-lg bg-white/10 px-4 py-2.5 text-sm text-white placeholder-gray-500 ring-1 ring-white/20 transition-all outline-none"
+            disabled={selectedGenreIds.size >= 5}
+            className="focus:ring-h_red flex-1 rounded-lg bg-white/10 px-4 py-2.5 text-sm text-white placeholder-gray-500 ring-1 ring-white/20 transition-all outline-none disabled:opacity-40"
           />
           <button
             type="button"
             onClick={handleAddGenre}
-            disabled={!newGenreInput.trim() || addingGenre}
+            disabled={
+              !newGenreInput.trim() || addingGenre || selectedGenreIds.size >= 5
+            }
             className="bg-h_red hover:bg-h_redDark flex shrink-0 items-center gap-1.5 rounded-lg px-4 py-2.5 text-sm font-medium text-white transition-colors disabled:opacity-50"
           >
             {addingGenre ? (

--- a/src/components/dj-profile/DjProfileFree.tsx
+++ b/src/components/dj-profile/DjProfileFree.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -11,6 +11,8 @@ import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 import { formatNumber } from "@/lib/utils/currency";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { toast } from "sonner";
+import { uploadDjCover } from "@/lib/actions/dj-upload";
 import {
   MapPin,
   Users,
@@ -32,6 +34,8 @@ import {
   BriefcaseBusiness,
   Pencil,
   ImageIcon,
+  Camera,
+  Loader2,
 } from "lucide-react";
 import type { DjDemoData, ViewMode } from "@/types/dj-demo";
 import MediaAudioPlayer from "@/components/dj-profile/MediaAudioPlayer";
@@ -129,6 +133,32 @@ export default function DjProfileFree({
 
   const isOwner = viewMode === "dj-owner";
   const editHref = djData?.slug ? `/djs/${djData.slug}/edit` : "#";
+
+  const [coverUrl, setCoverUrl] = useState(DJ.coverImage);
+  const [isUploadingCover, setIsUploadingCover] = useState(false);
+  const coverInputRef = useRef<HTMLInputElement>(null);
+
+  async function handleCoverChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setIsUploadingCover(true);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const result = await uploadDjCover(fd);
+      if ("error" in result) {
+        toast.error(result.error);
+      } else {
+        setCoverUrl(result.url);
+        toast.success("Cover image updated");
+      }
+    } catch {
+      toast.error("Upload failed. Please try again.");
+    } finally {
+      setIsUploadingCover(false);
+      e.target.value = "";
+    }
+  }
   const bookingEmail = djData
     ? djData.booking.email
     : FREE_DEFAULT_DJ.bookingEmail;
@@ -156,7 +186,7 @@ export default function DjProfileFree({
       <section className="w-full">
         <div className="relative h-64 w-full overflow-hidden md:h-96">
           <Image
-            src={DJ.coverImage}
+            src={coverUrl}
             alt="cover"
             fill
             className="object-cover"
@@ -164,6 +194,30 @@ export default function DjProfileFree({
           />
           <div className="absolute inset-0 bg-linear-to-t from-black via-black/40 to-transparent" />
           <div className="from-h_red/8 absolute inset-0 bg-linear-to-r to-transparent" />
+          {isOwner && (
+            <>
+              <button
+                type="button"
+                onClick={() => coverInputRef.current?.click()}
+                disabled={isUploadingCover}
+                className="absolute top-3 right-3 z-10 flex items-center gap-1.5 rounded-lg bg-black/50 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-black/70 disabled:opacity-50"
+              >
+                {isUploadingCover ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Camera className="h-3.5 w-3.5" />
+                )}
+                Change Cover
+              </button>
+              <input
+                ref={coverInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                className="hidden"
+                onChange={handleCoverChange}
+              />
+            </>
+          )}
         </div>
 
         <div className="mx-auto max-w-6xl px-4 md:px-8">

--- a/src/components/dj-profile/DjProfilePremium.tsx
+++ b/src/components/dj-profile/DjProfilePremium.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -11,6 +11,8 @@ import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 import { formatNumber } from "@/lib/utils/currency";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { toast } from "sonner";
+import { uploadDjCover } from "@/lib/actions/dj-upload";
 import {
   MapPin,
   Star,
@@ -41,6 +43,8 @@ import {
   Eye,
   CalendarCheck2,
   Handshake,
+  Camera,
+  Loader2,
 } from "lucide-react";
 import type { DjDemoData, ViewMode } from "@/types/dj-demo";
 import MediaVideoModal from "@/components/dj-profile/MediaVideoModal";
@@ -164,13 +168,41 @@ export default function DjProfilePremium({
   const SPOTLIGHT = djData ? djData.spotlight : PREMIUM_DEFAULT_SPOTLIGHT;
   const location = `${DJ.city}, ${DJ.country}`;
 
+  const isOwner = viewMode === "dj-owner";
+
+  const [coverUrl, setCoverUrl] = useState(DJ.coverImage);
+  const [isUploadingCover, setIsUploadingCover] = useState(false);
+  const coverInputRef = useRef<HTMLInputElement>(null);
+
+  async function handleCoverChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setIsUploadingCover(true);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const result = await uploadDjCover(fd);
+      if ("error" in result) {
+        toast.error(result.error);
+      } else {
+        setCoverUrl(result.url);
+        toast.success("Cover image updated");
+      }
+    } catch {
+      toast.error("Upload failed. Please try again.");
+    } finally {
+      setIsUploadingCover(false);
+      e.target.value = "";
+    }
+  }
+
   return (
     <div className="min-h-screen bg-black">
       {/* ── PREMIUM HERO ── */}
       <section className="w-full">
         <div className="relative h-72 w-full overflow-hidden md:h-105">
           <Image
-            src={DJ.coverImage}
+            src={coverUrl}
             alt="cover"
             fill
             className="object-cover"
@@ -180,6 +212,30 @@ export default function DjProfilePremium({
           <div className="from-h_red/10 absolute inset-0 bg-linear-to-r to-transparent" />
           {/* Premium ambient glow */}
           <div className="absolute right-0 bottom-0 left-0 h-32 bg-linear-to-t from-black to-transparent" />
+          {isOwner && (
+            <>
+              <button
+                type="button"
+                onClick={() => coverInputRef.current?.click()}
+                disabled={isUploadingCover}
+                className="absolute top-3 right-3 z-10 flex items-center gap-1.5 rounded-lg bg-black/50 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-black/70 disabled:opacity-50"
+              >
+                {isUploadingCover ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Camera className="h-3.5 w-3.5" />
+                )}
+                Change Cover
+              </button>
+              <input
+                ref={coverInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                className="hidden"
+                onChange={handleCoverChange}
+              />
+            </>
+          )}
         </div>
 
         <div className="mx-auto max-w-6xl px-4 md:px-8">

--- a/src/components/dj-profile/EditDjProfileForm.tsx
+++ b/src/components/dj-profile/EditDjProfileForm.tsx
@@ -112,6 +112,9 @@ const DJ_TYPE_LABELS: Record<string, string> = {
   FESTIVAL: "Festival",
   CORPORATE: "Corporate Event",
   BAR_LOUNGE: "Bar / Lounge",
+  PRIVATE_PARTY: "Private Party",
+  BIRTHDAY: "Birthday",
+  CULTURAL_EVENT: "Cultural Event",
 };
 
 interface ProfileData {
@@ -275,6 +278,7 @@ export default function EditDjProfileForm({
 
   function addGenre() {
     const trimmed = genreInput.trim();
+    if (genreNames.length >= 5) return;
     if (trimmed && !genreNames.includes(trimmed)) {
       setGenreNames((prev) => [...prev, trimmed]);
     }
@@ -394,6 +398,9 @@ export default function EditDjProfileForm({
           | "FESTIVAL"
           | "CORPORATE"
           | "BAR_LOUNGE"
+          | "PRIVATE_PARTY"
+          | "BIRTHDAY"
+          | "CULTURAL_EVENT"
         )[],
         socialLinks: validLinks,
         bookingEmail: bookingEmail.trim() || null,
@@ -684,11 +691,15 @@ export default function EditDjProfileForm({
                 <Label className="text-xs text-gray-300">
                   Genres <span className="text-h_red">*</span>
                 </Label>
-                {submitted && genresError && (
-                  <span className="text-[11px] text-red-400">
-                    Add at least one genre
-                  </span>
-                )}
+                <span
+                  className={`text-[11px] ${genreNames.length >= 5 ? "text-amber-400" : "text-gray-600"}`}
+                >
+                  {submitted && genresError ? (
+                    <span className="text-red-400">Add at least one genre</span>
+                  ) : (
+                    `${genreNames.length}/5`
+                  )}
+                </span>
               </div>
               <div className="mb-2 flex flex-wrap gap-1.5">
                 {genreNames.map((g) => (
@@ -718,16 +729,22 @@ export default function EditDjProfileForm({
                       addGenre();
                     }
                   }}
-                  placeholder="Type a genre and press Enter"
-                  className="focus:border-h_red/50 border-white/10 bg-white/5 text-white placeholder:text-gray-600"
+                  placeholder={
+                    genreNames.length >= 5
+                      ? "Max 5 genres reached"
+                      : "Type a genre and press Enter"
+                  }
+                  className="focus:border-h_red/50 border-white/10 bg-white/5 text-white placeholder:text-gray-600 disabled:opacity-40"
                   maxLength={50}
+                  disabled={genreNames.length >= 5}
                 />
                 <Button
                   type="button"
                   variant="outline"
                   size="sm"
                   onClick={addGenre}
-                  className="shrink-0 border-white/15 text-gray-300 hover:bg-white/5"
+                  disabled={genreNames.length >= 5}
+                  className="shrink-0 border-white/15 text-gray-300 hover:bg-white/5 disabled:opacity-40"
                 >
                   <Plus className="h-3.5 w-3.5" />
                 </Button>

--- a/src/lib/actions/profile.ts
+++ b/src/lib/actions/profile.ts
@@ -93,12 +93,24 @@ const DjProfileInputSchema = z.object({
   cityId: z.number().int().positive(),
   genreIds: z
     .array(z.number().int().positive())
-    .min(1, "Select at least one genre"),
+    .min(1, "Select at least one genre")
+    .max(5, "Select up to 5 genres"),
   socialLinks: z
     .array(z.object({ platform: z.string(), url: z.string().url() }))
     .min(1, "Add at least one social media link"),
   djTypes: z
-    .array(z.enum(["CLUB", "WEDDING", "FESTIVAL", "CORPORATE", "BAR_LOUNGE"]))
+    .array(
+      z.enum([
+        "CLUB",
+        "WEDDING",
+        "FESTIVAL",
+        "CORPORATE",
+        "BAR_LOUNGE",
+        "PRIVATE_PARTY",
+        "BIRTHDAY",
+        "CULTURAL_EVENT",
+      ]),
+    )
     .min(1, "Select at least one DJ type"),
   media: z.array(
     z.object({
@@ -126,7 +138,10 @@ const UpdateDjProfileSchema = z.object({
   coverImageUrl: z.string().url().optional().nullable(),
   countryId: z.number().int().positive().optional(),
   cityId: z.number().int().positive().optional(),
-  genreNames: z.array(z.string().min(1).max(50)).max(12).optional(),
+  genreNames: z
+    .array(z.string().min(1).max(50))
+    .max(5, "Select up to 5 genres")
+    .optional(),
   socialLinks: z
     .array(
       z.object({
@@ -136,7 +151,18 @@ const UpdateDjProfileSchema = z.object({
     )
     .optional(),
   djTypes: z
-    .array(z.enum(["CLUB", "WEDDING", "FESTIVAL", "CORPORATE", "BAR_LOUNGE"]))
+    .array(
+      z.enum([
+        "CLUB",
+        "WEDDING",
+        "FESTIVAL",
+        "CORPORATE",
+        "BAR_LOUNGE",
+        "PRIVATE_PARTY",
+        "BIRTHDAY",
+        "CULTURAL_EVENT",
+      ]),
+    )
     .optional(),
   bookingEmail: z.string().email("Invalid email address").optional().nullable(),
   bookingPhone: z.string().max(30).optional().nullable(),


### PR DESCRIPTION
…oad for profile owners

- Add max 5 genre validation to BecomeDjForm, EditDjProfileForm, and profile schemas
- Add genre counter display (x/5) with amber highlight when limit reached
- Disable genre input and add button when 5 genres selected
- Update placeholder text to indicate max limit
- Add cover image upload functionality to DjProfileFree and DjProfilePremium
- Add Camera button overlay on cover images for profile owners
- Add upload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Cover Image Uploads**: Profile owners can now upload and change their DJ cover image with success/error notifications.
* **New DJ Types**: Added Private Party, Birthday, and Cultural Event as available DJ type options.
* **Genre Selection Limit**: Genre selection now capped at 5 items with a live counter display (e.g., "3/5"). UI elements disable when the limit is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->