### PR TITLE
refactor: add displayName field to signup flow and personalize welcom…

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -119,6 +119,17 @@ export async function GET(request: Request) {
         });
         isNewUser = !prior;
 
+        // If a stale DB record exists for this email under a different auth ID
+        // (can happen when the Supabase Auth account was deleted and re-created),
+        // remove it so the upsert create path doesn't hit the email unique constraint.
+        const stale = await tx.user.findUnique({
+          where: { email },
+          select: { id: true },
+        });
+        if (stale && stale.id !== userId) {
+          await tx.user.delete({ where: { id: stale.id } });
+        }
+
         await tx.user.upsert({
           where: { id: userId },
           update: { email },
@@ -145,8 +156,13 @@ export async function GET(request: Request) {
         dbRoles = roleRecords.map((r) => r.role);
       });
     } catch (err) {
-      console.error("[auth/callback] DB transaction error:", err);
-      return NextResponse.redirect(`${origin}/sign-in?error=db_error`);
+      const detail = err instanceof Error ? err.message : String(err);
+      console.error("[auth/callback] DB transaction error:", detail);
+      const msg =
+        process.env.NODE_ENV === "development"
+          ? encodeURIComponent(detail.slice(0, 150))
+          : "db_error";
+      return NextResponse.redirect(`${origin}/sign-in?error=${msg}`);
     }
 
     if (isNewUser) {

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -8,6 +8,7 @@ import {
   welcomeEmailSubject,
   welcomeEmailHtml,
 } from "@/lib/email/templates/welcome";
+import { generateWelcomeCta } from "@/lib/supabase/admin";
 import { roleSchema } from "@/lib/validations/auth";
 
 export async function GET(request: Request) {
@@ -74,7 +75,10 @@ export async function GET(request: Request) {
     const username =
       user.user_metadata?.username ??
       email.split("@")[0] + "_" + user.id.slice(0, 6);
-    const name = user.user_metadata?.name ?? email.split("@")[0];
+    const name =
+      user.user_metadata?.displayName ??
+      user.user_metadata?.name ??
+      email.split("@")[0];
     const userId = user.id;
 
     // Role resolution priority: URL param → cookie → user_metadata
@@ -146,12 +150,13 @@ export async function GET(request: Request) {
     }
 
     if (isNewUser) {
+      const ctaUrl = await generateWelcomeCta(email);
       await sendEmail({
         to: email,
         userId,
         emailType: "WELCOME",
         subject: welcomeEmailSubject,
-        html: welcomeEmailHtml({ name }),
+        html: welcomeEmailHtml({ name, ctaUrl }),
       });
     }
 

--- a/src/app/sign-up/[[...sign-up]]/SignUpForm.tsx
+++ b/src/app/sign-up/[[...sign-up]]/SignUpForm.tsx
@@ -174,6 +174,13 @@ export default function SignUpForm({
       <form action={signUp} className="flex flex-col gap-4">
         <input type="hidden" name="role" value={selected} />
         <input
+          type="text"
+          name="displayName"
+          placeholder="Your name (e.g. DJ Hassan)"
+          maxLength={50}
+          className="focus:ring-h_red rounded-lg bg-white/10 px-4 py-3 text-white placeholder-gray-400 ring-1 ring-white/20 transition-all outline-none"
+        />
+        <input
           type="email"
           name="email"
           placeholder="Email"

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -16,6 +16,7 @@ import {
   welcomeEmailSubject,
   welcomeEmailHtml,
 } from "@/lib/email/templates/welcome";
+import { generateWelcomeCta } from "@/lib/supabase/admin";
 import {
   securityAlertSubject,
   securityAlertEmailHtml,
@@ -52,24 +53,28 @@ export async function signIn(formData: FormData) {
 }
 
 export async function signUp(formData: FormData) {
+  const rawDisplayName =
+    (formData.get("displayName") as string | null)?.trim() ?? "";
+
   const parsed = signUpSchema.safeParse({
     email: formData.get("email"),
     password: formData.get("password"),
     role: formData.get("role") ?? "",
+    displayName: rawDisplayName || undefined,
   });
   if (!parsed.success) {
     const message = parsed.error.errors[0]?.message ?? "Invalid input";
     redirect(`/sign-up?error=${encodeURIComponent(message)}`);
   }
 
-  const { email, password, role } = parsed.data;
+  const { email, password, role, displayName } = parsed.data;
   const supabase = await createClient();
 
   const { data, error } = await supabase.auth.signUp({
     email,
     password,
     options: {
-      data: { role }, // role stored in user_metadata — callback reads this (never from URL)
+      data: { role, displayName }, // stored in user_metadata — callback reads this
       emailRedirectTo: `${BASE_URL}/auth/callback`,
     },
   });
@@ -80,7 +85,8 @@ export async function signUp(formData: FormData) {
     const userId = data.user.id;
     const userEmail = data.user.email ?? "";
     const username = `${userEmail.split("@")[0]}-${userId.slice(0, 6)}`;
-    const name = userEmail.split("@")[0];
+    const emailPrefix = userEmail.split("@")[0];
+    const name = displayName || emailPrefix;
 
     try {
       await prisma.$transaction(async (tx) => {
@@ -104,13 +110,15 @@ export async function signUp(formData: FormData) {
         }
       });
 
+      const ctaUrl = await generateWelcomeCta(userEmail);
+
       // Welcome email for immediate signup (no email confirmation)
       await sendEmail({
         to: userEmail,
         userId,
         emailType: "WELCOME",
         subject: welcomeEmailSubject,
-        html: welcomeEmailHtml({ name }),
+        html: welcomeEmailHtml({ name, ctaUrl }),
       });
     } catch {
       await supabase.auth.signOut();

--- a/src/lib/email/templates/welcome.ts
+++ b/src/lib/email/templates/welcome.ts
@@ -2,8 +2,13 @@ import { baseLayout, escapeHtml } from "./base";
 
 export const welcomeEmailSubject = "Welcome to DJcovery 🎵";
 
-export function welcomeEmailHtml({ name }: { name: string }): string {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "https://djcovery.com";
+export function welcomeEmailHtml({
+  name,
+  ctaUrl,
+}: {
+  name: string;
+  ctaUrl: string;
+}): string {
   const displayName = escapeHtml(name.charAt(0).toUpperCase() + name.slice(1));
 
   return baseLayout(`
@@ -37,7 +42,7 @@ export function welcomeEmailHtml({ name }: { name: string }): string {
     <table cellpadding="0" cellspacing="0">
       <tr>
         <td>
-          <a href="${baseUrl}"
+          <a href="${ctaUrl}"
              style="display:inline-block;background:#e11d48;color:#ffffff;font-weight:700;font-size:14px;text-decoration:none;padding:12px 28px;border-radius:8px;">
             Explore DJcovery →
           </a>

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,0 +1,36 @@
+import { createClient } from "@supabase/supabase-js";
+
+export function createAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    },
+  );
+}
+
+/**
+ * Generates a one-time magic-link for the welcome email CTA.
+ * Falls back to baseUrl if the service-role key is not configured.
+ */
+export async function generateWelcomeCta(email: string): Promise<string> {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "https://djcovery.com";
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) return baseUrl;
+
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin.auth.admin.generateLink({
+      type: "magiclink",
+      email,
+      options: { redirectTo: `${baseUrl}/auth/callback` },
+    });
+    if (error || !data?.properties?.action_link) return baseUrl;
+    return data.properties.action_link;
+  } catch {
+    return baseUrl;
+  }
+}

--- a/src/lib/validations/auth.ts
+++ b/src/lib/validations/auth.ts
@@ -21,6 +21,7 @@ export const signUpSchema = z.object({
   email: z.string().email("Invalid email address"),
   password: passwordSchema,
   role: roleSchema.default(""),
+  displayName: z.string().max(50, "Display name is too long").optional(),
 });
 
 export const forgotPasswordSchema = z.object({


### PR DESCRIPTION
…e email CTA

- Add displayName input field to SignUpForm with 50 character max
- Add displayName to signUpSchema validation (optional, max 50 chars)
- Pass displayName through signup flow to user_metadata
- Update name resolution in OAuth callback to prioritize displayName over name metadata
- Update name resolution in signUp action to use displayName when available
- Add generateWelcomeCta helper import to generate personalized CTA URLs