### PR TITLE
refactor: add welcome email redirect flow and fan profile setup action

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -176,6 +176,20 @@ export async function GET(request: Request) {
       });
     }
 
+    // Welcome email CTA — role-aware redirect so users complete their profile
+    if (searchParams.get("welcome") === "true") {
+      if (dbRoles.includes("ADMIN"))
+        return NextResponse.redirect(`${origin}/admin`);
+      if (dbRoles.includes("DJ"))
+        return NextResponse.redirect(`${origin}/dashboard`);
+      if (dbRoles.includes("ORGANIZER"))
+        return NextResponse.redirect(`${origin}/organizer/dashboard`);
+      if (role === "dj") return NextResponse.redirect(`${origin}/become-dj`);
+      if (role === "organizer")
+        return NextResponse.redirect(`${origin}/become-organizer`);
+      return NextResponse.redirect(`${origin}/become-fan`);
+    }
+
     // Existing users → redirect to their dashboard
     if (dbRoles.includes("ADMIN"))
       return NextResponse.redirect(`${origin}/admin`);

--- a/src/app/become-fan/page.tsx
+++ b/src/app/become-fan/page.tsx
@@ -1,0 +1,52 @@
+import { createClient } from "@/lib/supabase/server";
+import prisma from "@/lib/client";
+import { redirect } from "next/navigation";
+import { getCountries } from "@/lib/actions/locations";
+import BecomeFanForm from "@/components/BecomeFanForm";
+import Footer from "@/components/Footer";
+
+export const metadata = { title: "Complete Your Profile" };
+
+export default async function BecomeFanPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/sign-in");
+
+  const [fanProfile, countries] = await Promise.all([
+    prisma.fanProfile.findUnique({
+      where: { userId: user.id },
+      select: { name: true },
+    }),
+    getCountries(),
+  ]);
+
+  return (
+    <>
+      <div className="min-h-[calc(100vh-96px)] flex items-center justify-center px-4 py-12">
+        <div className="w-full max-w-lg">
+          <div className="text-center mb-8 space-y-2">
+            <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-h_red/20 border border-h_red/40 mb-2">
+              <span className="text-2xl">🎧</span>
+            </div>
+            <h1 className="text-3xl font-bold text-white">
+              Complete Your Profile
+            </h1>
+            <p className="text-gray-400 text-sm max-w-sm mx-auto">
+              Add a few details so other fans, DJs, and organizers can get to
+              know you on DJcovery.
+            </p>
+          </div>
+
+          <BecomeFanForm
+            initialName={fanProfile?.name ?? ""}
+            countries={countries}
+          />
+        </div>
+      </div>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/become-fan/page.tsx
+++ b/src/app/become-fan/page.tsx
@@ -18,23 +18,23 @@ export default async function BecomeFanPage() {
   const [fanProfile, countries] = await Promise.all([
     prisma.fanProfile.findUnique({
       where: { userId: user.id },
-      select: { name: true },
+      select: { name: true, bio: true, countryId: true },
     }),
     getCountries(),
   ]);
 
   return (
     <>
-      <div className="min-h-[calc(100vh-96px)] flex items-center justify-center px-4 py-12">
+      <div className="flex min-h-[calc(100vh-96px)] items-center justify-center px-4 py-12">
         <div className="w-full max-w-lg">
-          <div className="text-center mb-8 space-y-2">
-            <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-h_red/20 border border-h_red/40 mb-2">
+          <div className="mb-8 space-y-2 text-center">
+            <div className="bg-h_red/20 border-h_red/40 mb-2 inline-flex h-14 w-14 items-center justify-center rounded-full border">
               <span className="text-2xl">🎧</span>
             </div>
             <h1 className="text-3xl font-bold text-white">
               Complete Your Profile
             </h1>
-            <p className="text-gray-400 text-sm max-w-sm mx-auto">
+            <p className="mx-auto max-w-sm text-sm text-gray-400">
               Add a few details so other fans, DJs, and organizers can get to
               know you on DJcovery.
             </p>
@@ -42,6 +42,8 @@ export default async function BecomeFanPage() {
 
           <BecomeFanForm
             initialName={fanProfile?.name ?? ""}
+            initialBio={fanProfile?.bio ?? ""}
+            initialCountryId={fanProfile?.countryId ?? null}
             countries={countries}
           />
         </div>

--- a/src/components/BecomeFanForm.tsx
+++ b/src/components/BecomeFanForm.tsx
@@ -11,9 +11,13 @@ const initialState = { success: false, error: null as string | null };
 
 export default function BecomeFanForm({
   initialName,
+  initialBio,
+  initialCountryId,
   countries,
 }: {
   initialName: string;
+  initialBio: string;
+  initialCountryId: number | null;
   countries: Country[];
 }) {
   const router = useRouter();
@@ -59,15 +63,16 @@ export default function BecomeFanForm({
       <div className="flex flex-col gap-1.5">
         <label htmlFor="bio" className="text-sm font-medium text-gray-300">
           Bio{" "}
-          <span className="text-gray-500 font-normal text-xs">(optional)</span>
+          <span className="text-xs font-normal text-gray-500">(optional)</span>
         </label>
         <textarea
           id="bio"
           name="bio"
+          defaultValue={initialBio}
           rows={3}
           maxLength={300}
           placeholder="Tell us a bit about yourself..."
-          className="focus:ring-h_red rounded-lg bg-white/10 px-4 py-3 text-white placeholder-gray-500 ring-1 ring-white/20 transition-all outline-none resize-none"
+          className="focus:ring-h_red resize-none rounded-lg bg-white/10 px-4 py-3 text-white placeholder-gray-500 ring-1 ring-white/20 transition-all outline-none"
         />
       </div>
 
@@ -77,12 +82,12 @@ export default function BecomeFanForm({
           className="text-sm font-medium text-gray-300"
         >
           Country{" "}
-          <span className="text-gray-500 font-normal text-xs">(optional)</span>
+          <span className="text-xs font-normal text-gray-500">(optional)</span>
         </label>
         <select
           id="countryId"
           name="countryId"
-          defaultValue=""
+          defaultValue={initialCountryId?.toString() ?? ""}
           className="focus:ring-h_red appearance-none rounded-lg bg-white/10 px-4 py-3 text-white ring-1 ring-white/20 transition-all outline-none"
         >
           <option value="" className="bg-gray-900">
@@ -107,7 +112,7 @@ export default function BecomeFanForm({
       <button
         type="button"
         onClick={() => router.push("/")}
-        className="text-center text-sm text-gray-500 hover:text-gray-300 transition-colors"
+        className="text-center text-sm text-gray-500 transition-colors hover:text-gray-300"
       >
         Skip for now
       </button>

--- a/src/components/BecomeFanForm.tsx
+++ b/src/components/BecomeFanForm.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useActionState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { setupFanProfile } from "@/lib/actions/profile";
+
+type Country = { id: number; name: string };
+
+const initialState = { success: false, error: null as string | null };
+
+export default function BecomeFanForm({
+  initialName,
+  countries,
+}: {
+  initialName: string;
+  countries: Country[];
+}) {
+  const router = useRouter();
+  const [state, formAction, isPending] = useActionState(
+    setupFanProfile,
+    initialState,
+  );
+
+  useEffect(() => {
+    if (state.success) {
+      toast.success("Profile saved! Welcome to DJcovery 🎉");
+      router.push("/");
+    }
+    if (state.error) {
+      toast.error(state.error);
+    }
+  }, [state, router]);
+
+  return (
+    <form
+      action={formAction}
+      className="flex flex-col gap-5 rounded-xl border border-white/10 bg-white/5 p-8"
+    >
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="name" className="text-sm font-medium text-gray-300">
+          Display Name <span className="text-h_red">*</span>
+        </label>
+        <input
+          id="name"
+          type="text"
+          name="name"
+          defaultValue={initialName}
+          required
+          maxLength={50}
+          placeholder="e.g. John Doe"
+          className="focus:ring-h_red rounded-lg bg-white/10 px-4 py-3 text-white placeholder-gray-500 ring-1 ring-white/20 transition-all outline-none"
+        />
+        <p className="text-xs text-gray-500">
+          This is how other users will see you on DJcovery.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="bio" className="text-sm font-medium text-gray-300">
+          Bio{" "}
+          <span className="text-gray-500 font-normal text-xs">(optional)</span>
+        </label>
+        <textarea
+          id="bio"
+          name="bio"
+          rows={3}
+          maxLength={300}
+          placeholder="Tell us a bit about yourself..."
+          className="focus:ring-h_red rounded-lg bg-white/10 px-4 py-3 text-white placeholder-gray-500 ring-1 ring-white/20 transition-all outline-none resize-none"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label
+          htmlFor="countryId"
+          className="text-sm font-medium text-gray-300"
+        >
+          Country{" "}
+          <span className="text-gray-500 font-normal text-xs">(optional)</span>
+        </label>
+        <select
+          id="countryId"
+          name="countryId"
+          defaultValue=""
+          className="focus:ring-h_red appearance-none rounded-lg bg-white/10 px-4 py-3 text-white ring-1 ring-white/20 transition-all outline-none"
+        >
+          <option value="" className="bg-gray-900">
+            Select your country...
+          </option>
+          {countries.map((c) => (
+            <option key={c.id} value={c.id} className="bg-gray-900">
+              {c.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <button
+        type="submit"
+        disabled={isPending}
+        className="bg-h_red hover:bg-h_redDark w-full rounded-lg py-3 font-bold text-white transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isPending ? "Saving..." : "Get started →"}
+      </button>
+
+      <button
+        type="button"
+        onClick={() => router.push("/")}
+        className="text-center text-sm text-gray-500 hover:text-gray-300 transition-colors"
+      >
+        Skip for now
+      </button>
+    </form>
+  );
+}

--- a/src/lib/actions/profile.ts
+++ b/src/lib/actions/profile.ts
@@ -681,3 +681,40 @@ export async function deleteOrganizerProfile(): Promise<
     return { error: "Something went wrong. Please try again." };
   }
 }
+
+export async function setupFanProfile(
+  _prevState: { success: boolean; error: string | null },
+  formData: FormData,
+): Promise<{ success: boolean; error: string | null }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { success: false, error: "Not authenticated" };
+
+  const name = (formData.get("name") as string)?.trim();
+  if (!name) return { success: false, error: "Name is required" };
+  if (name.length > 50)
+    return { success: false, error: "Name is too long (max 50 characters)" };
+
+  const bio = (formData.get("bio") as string)?.trim() || null;
+  const rawCountryId = formData.get("countryId");
+  const countryId =
+    rawCountryId && rawCountryId !== ""
+      ? parseInt(rawCountryId as string, 10)
+      : null;
+
+  try {
+    await prisma.fanProfile.upsert({
+      where: { userId: user.id },
+      update: { name, bio, countryId },
+      create: { userId: user.id, name },
+    });
+    return { success: true, error: null };
+  } catch {
+    return {
+      success: false,
+      error: "Failed to save profile. Please try again.",
+    };
+  }
+}

--- a/src/lib/actions/profile.ts
+++ b/src/lib/actions/profile.ts
@@ -708,7 +708,7 @@ export async function setupFanProfile(
     await prisma.fanProfile.upsert({
       where: { userId: user.id },
       update: { name, bio, countryId },
-      create: { userId: user.id, name },
+      create: { userId: user.id, name, bio, countryId },
     });
     return { success: true, error: null };
   } catch {

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -26,7 +26,7 @@ export async function generateWelcomeCta(email: string): Promise<string> {
     const { data, error } = await admin.auth.admin.generateLink({
       type: "magiclink",
       email,
-      options: { redirectTo: `${baseUrl}/auth/callback` },
+      options: { redirectTo: `${baseUrl}/auth/callback?welcome=true` },
     });
     if (error || !data?.properties?.action_link) return baseUrl;
     return data.properties.action_link;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -36,6 +36,7 @@ export async function middleware(request: NextRequest) {
     "/select-role",
     "/become-dj",
     "/become-organizer",
+    "/become-fan",
     "/organizer",
     "/settings",
     "/profile/edit",


### PR DESCRIPTION
- Add welcome=true query param handling to OAuth callback route
- Redirect users to role-specific onboarding pages when arriving from welcome email
- Check existing roles first (ADMIN/DJ/ORGANIZER) and redirect to dashboards
- Fall back to role-based onboarding pages (become-dj/become-organizer/become-fan)
- Add setupFanProfile server action to handle fan profile creation/updates
- Validate name field (required, max 50 chars)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added role-aware onboarding flow that directs users to appropriate completion pages after welcome email sign-in
  * Introduced "Complete Your Profile" page allowing fans to add display name, bio, and country information
  * Added form validation and success notifications for profile completion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->