### PR TITLE
refactor: replace Headphones icon with AudioLines in directory pages …

### DIFF
--- a/src/app/directory/loading.tsx
+++ b/src/app/directory/loading.tsx
@@ -1,5 +1,5 @@
 import { DjGridSkeleton, FilterPanelSkeleton } from "@/components/ui/skeletons";
-import { Headphones } from "lucide-react";
+import { AudioLines, Headphones } from "lucide-react";
 
 export default function DirectoryLoading() {
   return (
@@ -10,7 +10,7 @@ export default function DirectoryLoading() {
           {/* Left — icon box + title + subtitle */}
           <div className="flex items-center gap-4">
             <div className="bg-h_red/10 border-h_red/20 flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border">
-              <Headphones className="text-h_red h-6 w-6" />
+              <AudioLines className="text-h_red h-6 w-6" />
             </div>
             <div className="flex flex-col gap-1">
               <h1 className="text-h_white text-3xl font-bold md:text-5xl">

--- a/src/app/directory/page.tsx
+++ b/src/app/directory/page.tsx
@@ -10,7 +10,7 @@ import ActiveFilterBadges from "@/components/directory/ActiveFilterBadges";
 import EventCalendar from "@/components/directory/EventCalendar";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faHeadphones } from "@fortawesome/free-solid-svg-icons";
-import { Headphones } from "lucide-react";
+import { AudioLines, Headphones } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 
 type SearchParams = {
@@ -304,7 +304,7 @@ const DirectoryPage = async ({
         <div className="mx-auto flex w-full max-w-7xl flex-col items-start justify-between gap-4 px-4 sm:flex-row sm:items-center md:px-8">
           <div className="flex items-center gap-4">
             <div className="bg-h_red/10 border-h_red/20 flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border">
-              <Headphones className="text-h_red h-6 w-6" />
+              <AudioLines className="text-h_red h-6 w-6" />
             </div>
             <div className="flex flex-col gap-1">
               <h1 className="text-h_white text-2xl font-bold tracking-tight md:text-4xl lg:text-5xl">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -209,7 +209,7 @@ const Footer = async () => {
               <h4 className="text-xs font-semibold tracking-[0.15em] text-white uppercase">
                 Company
               </h4>
-              <ul className="flex flex-col gap-3">
+              <ul className="flex flex-col">
                 {companyLinks.map((link) => (
                   <li key={link.label}>
                     <Link
@@ -223,7 +223,7 @@ const Footer = async () => {
               </ul>
 
               {/* App badge placeholder */}
-              <div className="mt-4 flex flex-col gap-2">
+              <div className="mt-5 flex flex-col gap-2">
                 <p className="text-xs tracking-widest text-gray-600 uppercase">
                   Coming soon
                 </p>

--- a/src/components/events/EventGrid.tsx
+++ b/src/components/events/EventGrid.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { EventCard, type EventCardItem } from "./EventCard";
 
-const PAGE_SIZE = 9;
+const PAGE_SIZE = 12;
 
 export function EventGrid({
   events,


### PR DESCRIPTION
…and adjust footer spacing

- Import and use AudioLines icon instead of Headphones in directory page and loading skeleton
- Reduce gap in footer company links list from gap-3 to no gap
- Increase top margin of app badge section from mt-4 to mt-5
- Increase EventGrid page size from 9 to 12 items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the number of events shown at once and when loading more, so browsing events is faster.
  * Updated the directory hero artwork to a new icon for a refreshed look.

* **Style**
  * Tweaked footer spacing for a cleaner layout.
  * Adjusted spacing in the directory loading state for visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->