### PR TITLE
refactor: add icons to footer company links and adjust spacing

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,7 +9,7 @@ import {
   faTiktok,
   faXTwitter,
 } from "@fortawesome/free-brands-svg-icons";
-import { House, Mic, Mail } from "lucide-react";
+import { House, Mic, Mail, Info, CircleHelp } from "lucide-react";
 import { getNavUser } from "@/lib/auth/getNavUser";
 import {
   desktopNavByRole,
@@ -19,9 +19,9 @@ import {
 } from "@/config/navigation";
 
 const companyLinks = [
-  { label: "About DJcovery", href: "/about" },
-  { label: "FAQ", href: "/" },
-  { label: "Contact Us", href: "/" },
+  { label: "About DJcovery", href: "/about", icon: Info },
+  { label: "FAQ", href: "/", icon: CircleHelp },
+  { label: "Contact Us", href: "/", icon: Mail },
   // { label: "Privacy Policy", href: "/privacy-policy" },
   // { label: "Terms of Service", href: "/terms-of-service" },
   // { label: "Cookie Policy", href: "/cookie-policy" },
@@ -209,14 +209,17 @@ const Footer = async () => {
               <h4 className="text-xs font-semibold tracking-[0.15em] text-white uppercase">
                 Company
               </h4>
-              <ul className="flex flex-col">
+              <ul className="flex flex-col gap-4">
                 {companyLinks.map((link) => (
                   <li key={link.label}>
                     <Link
                       href={link.href}
-                      className="hover:text-h_red text-sm text-gray-400 transition-colors"
+                      className="hover:text-h_red group flex items-center gap-2.5 text-sm text-gray-400 transition-colors"
                     >
-                      {link.label}
+                      {link.icon && (
+                        <link.icon className="text-h_redDark h-3.5 w-3.5" />
+                      )}
+                      <span>{link.label}</span>
                     </Link>
                   </li>
                 ))}


### PR DESCRIPTION
- Import Info and CircleHelp icons from lucide-react
- Add icon property to companyLinks array with Info, CircleHelp, and Mail icons
- Update company links list gap from no gap to gap-4
- Add flex layout with gap-2.5 to link items to display icons
- Conditionally render icons with h-3.5 w-3.5 size and text-h_redDark color
- Wrap link label text in span element

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Company footer links can now display icons alongside link text.
  * Added visual icons for About, FAQ, and Contact links for quicker recognition.
  * Updated the footer link layout for better spacing and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->