### PR TITLE
refactor: fix follower count aggregation in directory and home DJ com…

### DIFF
--- a/src/app/directory/page.tsx
+++ b/src/app/directory/page.tsx
@@ -90,9 +90,7 @@ const DirectoryPage = async ({
             ? { stageName: "desc" }
             : [{ searchScore: "desc" }, { reputationScore: "desc" }],
       include: {
-        user: {
-          include: { _count: { select: { followers: true } } },
-        },
+        user: true,
         country: { select: { name: true } },
         city: { select: { name: true } },
         genres: { include: { genre: { select: { name: true } } } },
@@ -100,6 +98,7 @@ const DirectoryPage = async ({
         gigReviews: { select: { id: true } },
         eventReviews: { select: { id: true } },
         ratings: { select: { id: true } },
+        _count: { select: { followers: true } },
       },
     });
 
@@ -117,7 +116,7 @@ const DirectoryPage = async ({
       isFeatured: p.featured,
       status: p.status,
       djTypes: p.djTypes.map((t) => t.type),
-      _count: { followers: p.user._count.followers },
+      _count: { followers: p._count.followers },
       reputationScore: p.reputationScore,
       gigReviews: p.gigReviews,
       eventReviews: p.eventReviews,

--- a/src/components/dj-profile/SaveDjButton.tsx
+++ b/src/components/dj-profile/SaveDjButton.tsx
@@ -74,9 +74,9 @@ export default function SaveDjButton({
       onClick={handleClick}
       disabled={isPending}
       aria-pressed={optimisticFollowing}
-      aria-label="Follow DJ"
+      aria-label={optimisticFollowing ? "Unfollow DJ" : "Follow DJ"}
       className={cn(
-        "group flex items-center gap-1.5 rounded-lg border px-4 py-2 text-sm font-medium transition-colors disabled:opacity-60",
+        "group flex cursor-pointer items-center gap-1.5 rounded-lg border px-4 py-2 text-sm font-medium transition-colors disabled:opacity-60",
         "focus-visible:ring-h_red focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none",
         optimisticFollowing
           ? "border-white/30 bg-white/10 text-white hover:border-red-500/40 hover:bg-red-500/10 hover:text-red-400 focus-visible:border-red-500/40 focus-visible:bg-red-500/10 focus-visible:text-red-400"

--- a/src/components/home/HomeDJsRow.tsx
+++ b/src/components/home/HomeDJsRow.tsx
@@ -103,7 +103,7 @@ export default function HomeDJsRow({
 
                   <div className="mt-auto flex items-center justify-between border-t border-white/5 pt-2 text-xs text-gray-400">
                     <span>⭐ {dj.rating}</span>
-                    <span>{formatNumber(dj.followers)} fans</span>
+                    <span>{formatNumber(dj.followers)} followers</span>
                   </div>
                 </Card>
               </Link>

--- a/src/components/home/HomeDJsTabs.tsx
+++ b/src/components/home/HomeDJsTabs.tsx
@@ -170,7 +170,7 @@ function DJCard({
 
         <div className="mt-auto flex items-center justify-between border-t border-white/5 pt-2 text-xs text-gray-400">
           <span>⭐ {dj.rating}</span>
-          <span>{formatNumber(dj.followers)} fans</span>
+          <span>{formatNumber(dj.followers)} followers</span>
         </div>
       </Card>
     </Link>

--- a/src/components/home/HomeDJsTabsAsync.tsx
+++ b/src/components/home/HomeDJsTabsAsync.tsx
@@ -38,21 +38,23 @@ export default async function HomeDJsTabsAsync() {
         orderBy: { createdAt: "desc" },
         take: 8,
         include: {
-          user: { include: { _count: { select: { followers: true } } } },
+          user: true,
           country: { select: { name: true } },
           city: { select: { name: true } },
           genres: { include: { genre: { select: { name: true } } } },
           ratings: { select: { rating: true } },
+          _count: { select: { followers: true } },
         },
       }),
       prisma.djProfile.findMany({
         where: { deletedAt: null, status: "APPROVED" },
         include: {
-          user: { include: { _count: { select: { followers: true } } } },
+          user: true,
           country: { select: { name: true } },
           city: { select: { name: true } },
           genres: { include: { genre: { select: { name: true } } } },
           ratings: { select: { rating: true } },
+          _count: { select: { followers: true } },
         },
       }),
     ]);
@@ -72,7 +74,7 @@ export default async function HomeDJsTabsAsync() {
                 10,
             ) / 10
           : 0,
-      followers: p.user._count.followers,
+      followers: p._count.followers,
       slug: p.slug,
       isPremium: p.plan === "PREMIUM",
     });


### PR DESCRIPTION
…ponents

- Move follower count from nested user._count to direct DJ profile _count in directory page
- Update HomeDJsTabsAsync to query _count at DJ profile level instead of nested user include
- Change "fans" label to "followers" in HomeDJsRow and HomeDJsTabs components
- Add cursor-pointer class and improve aria-label for SaveDjButton follow/unfollow states

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved follower counts shown on DJ directory and home listings so they display more reliably.
  * Updated labels from “fans” to “followers” across DJ cards and rows for consistency.
  * Made the save/follow button’s accessible label switch between “Follow DJ” and “Unfollow DJ” based on state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->