### PR TITLE
refactor: hide profile strength section from non-owners in DJ profile…

### DIFF
--- a/src/components/dj-profile/DjProfileFree.tsx
+++ b/src/components/dj-profile/DjProfileFree.tsx
@@ -529,27 +529,31 @@ export default function DjProfileFree({
               />
             </div>
 
-            <Separator className="bg-white/8" />
+            {isOwner && (
+              <>
+                <Separator className="bg-white/8" />
 
-            {/* Profile completion prompt */}
-            <div>
-              <div className="mb-2 flex items-center justify-between">
-                <span className="text-xs font-medium text-gray-400">
-                  Profile Strength
-                </span>
-                <span className="text-xs font-bold text-white">
-                  {completion ? `${completion.percentage}%` : "68%"}
-                </span>
-              </div>
-              <Progress
-                value={completion?.percentage ?? 68}
-                className="mb-2 h-1.5 bg-white/8"
-              />
-              <p className="text-xs text-gray-500">
-                {completion?.suggestions[0] ??
-                  "Add more photos & connect Spotify to reach 100%."}
-              </p>
-            </div>
+                {/* Profile completion prompt (owner only) */}
+                <div>
+                  <div className="mb-2 flex items-center justify-between">
+                    <span className="text-xs font-medium text-gray-400">
+                      Profile Strength
+                    </span>
+                    <span className="text-xs font-bold text-white">
+                      {completion ? `${completion.percentage}%` : "68%"}
+                    </span>
+                  </div>
+                  <Progress
+                    value={completion?.percentage ?? 68}
+                    className="mb-2 h-1.5 bg-white/8"
+                  />
+                  <p className="text-xs text-gray-500">
+                    {completion?.suggestions[0] ??
+                      "Add more photos & connect Spotify to reach 100%."}
+                  </p>
+                </div>
+              </>
+            )}
           </aside>
         </div>
       </div>


### PR DESCRIPTION
… sidebar

- Wrap profile completion prompt and separator in isOwner conditional
- Move profile strength indicator to owner-only section alongside other private metrics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Profile Strength” prompt in the sidebar now appears only for profile owners.
  * Non-owners will no longer see the completion percentage, progress indicator, or suggestion text in that area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->