### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/src/components/dj-profile/MediaAudioPlayer.tsx
+++ b/src/components/dj-profile/MediaAudioPlayer.tsx
@@ -12,7 +12,17 @@ type Props = {
 export default function MediaAudioPlayer({ audioUrl, title, children }: Props) {
   const [open, setOpen] = useState(false);
 
-  const isSoundCloud = audioUrl.includes("soundcloud.com");
+  let isSoundCloud = false;
+  try {
+    const { hostname } = new URL(audioUrl);
+    const normalizedHost = hostname.toLowerCase();
+    isSoundCloud =
+      normalizedHost === "soundcloud.com" ||
+      normalizedHost.endsWith(".soundcloud.com");
+  } catch {
+    isSoundCloud = false;
+  }
+
   const embedUrl = isSoundCloud
     ? `https://w.soundcloud.com/player/?url=${encodeURIComponent(audioUrl)}&auto_play=true&color=%23ff2200&buying=false&sharing=false&show_artwork=true&show_user=false`
     : null;


### PR DESCRIPTION
Potential fix for [https://github.com/hassanidris/djscovery/security/code-scanning/2](https://github.com/hassanidris/djscovery/security/code-scanning/2)

Use the `URL` parser and validate the **hostname** explicitly instead of checking a substring in the whole URL.

Best fix in this file:
- Replace `audioUrl.includes("soundcloud.com")` with parsed-host validation.
- Safely handle invalid URLs with `try/catch`.
- Allow only `soundcloud.com` and its subdomains via:
  - `hostname === "soundcloud.com"` OR
  - `hostname.endsWith(".soundcloud.com")`

This preserves existing behavior (build embed URL only for SoundCloud links) while removing bypasses caused by query/path/userinfo substrings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio source detection so SoundCloud links are recognized more reliably, including valid subdomains.
  * Added safer handling for invalid audio URLs to prevent unexpected detection errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->