### PR TITLE
refactor: add RLS policies for BookingInquiry and BookingInquiryMessa…

### DIFF
--- a/prisma/rls-policies.sql
+++ b/prisma/rls-policies.sql
@@ -71,3 +71,31 @@ CREATE POLICY "Involved users can read hire" ON "Hire" FOR SELECT TO public USIN
       AND (op."userId" = (auth.uid())::text OR dj."userId" = (auth.uid())::text)
   )
 );
+
+-- BookingInquiry: organizer and invited DJ can read
+ALTER TABLE "BookingInquiry" ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Participants can read booking inquiry" ON "BookingInquiry";
+CREATE POLICY "Participants can read booking inquiry" ON "BookingInquiry" FOR SELECT TO public USING (
+  (auth.uid())::text = "organizerId"
+  OR EXISTS (
+    SELECT 1 FROM "DjProfile" dj
+    WHERE dj.id = "BookingInquiry"."djProfileId"
+      AND dj."userId" = (auth.uid())::text
+  )
+);
+
+-- BookingInquiryMessage: sharers only
+ALTER TABLE "BookingInquiryMessage" ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Participants can read booking inquiry messages" ON "BookingInquiryMessage";
+CREATE POLICY "Participants can read booking inquiry messages" ON "BookingInquiryMessage" FOR SELECT TO public USING (
+  EXISTS (
+    SELECT 1
+    FROM "BookingInquiry" bi
+    JOIN "DjProfile" dj ON dj.id = bi."djProfileId"
+    WHERE bi.id = "BookingInquiryMessage"."inquiryId"
+      AND (
+        bi."organizerId" = (auth.uid())::text
+        OR dj."userId" = (auth.uid())::text
+      )
+  )
+);


### PR DESCRIPTION
…ge tables

- Enable row-level security on BookingInquiry and BookingInquiryMessage tables
- Add SELECT policy for BookingInquiry allowing organizer and invited DJ to read
- Add SELECT policy for BookingInquiryMessage allowing participants (organizer and DJ) to read messages
- Use EXISTS subqueries to verify user participation through organizerId and DjProfile.userId

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added row-level access controls for booking inquiries and related messages.
  * Users can now view booking inquiry details and messages only when they are directly involved in the booking.

* **Security**
  * Strengthened read permissions so booking information is available only to the organizer or the linked DJ account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->