### PR TITLE
refactor: add blob URL validation to avatar preview in BecomeDjForm

### DIFF
--- a/src/components/BecomeDjForm.tsx
+++ b/src/components/BecomeDjForm.tsx
@@ -353,7 +353,7 @@ export default function BecomeDjForm({
           >
             {avatarPreview ? (
               <img
-                src={avatarPreview}
+                src={avatarPreview.startsWith("blob:") ? avatarPreview : ""}
                 alt="Avatar preview"
                 className="h-full w-full object-cover"
               />


### PR DESCRIPTION
- Add startsWith("blob:") check before rendering avatarPreview src to prevent potential URL substring sanitization issues
- Set empty string fallback when avatarPreview is not a blob URL