### PR TITLE
feat(booking): add package selection to booking inquiry flow

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,9 @@ model BookingInquiry {
   message           String
   contactReleasedAt DateTime?
   lastRespondedAt   DateTime?
+  packageName       String?
+  packagePrice      Int?
+  packagePriceTo    Int?
 
   countryId Int?
   country   Country? @relation("BookingInquiryCountry", fields: [countryId], references: [id])

--- a/src/app/dashboard/dj/bookings/page.tsx
+++ b/src/app/dashboard/dj/bookings/page.tsx
@@ -95,6 +95,9 @@ export default async function DjBookingsPage() {
       counterpartyEmail: organizerEmail,
       contactVisible,
       messages,
+      packageName: inquiry.packageName,
+      packagePrice: inquiry.packagePrice,
+      packagePriceTo: inquiry.packagePriceTo,
     };
   });
 

--- a/src/app/djs/[slug]/page.tsx
+++ b/src/app/djs/[slug]/page.tsx
@@ -89,6 +89,12 @@ export default async function DjProfilePage({
       coverImage: true,
       countryId: true,
       cityId: true,
+      city: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
       plan: true,
       status: true,
       featured: true,
@@ -123,7 +129,6 @@ export default async function DjProfilePage({
           id: true,
         },
       },
-      city: true,
       country: true,
       genres: { include: { genre: true } },
       djTypes: true,
@@ -219,6 +224,12 @@ export default async function DjProfilePage({
           contactEmail: true,
           countryId: true,
           cityId: true,
+          city: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
       }),
     ]);
@@ -234,6 +245,8 @@ export default async function DjProfilePage({
       isAuthenticated: true,
       organizerDisplayName: organizerProfile?.displayName ?? undefined,
       organizerContactEmail: organizerProfile?.contactEmail ?? undefined,
+      organizerCityId: organizerProfile?.cityId ?? undefined,
+      organizerCityName: organizerProfile?.city?.name ?? undefined,
     };
 
     if (organizerProfile?.countryId && organizerProfile?.cityId) {
@@ -359,11 +372,15 @@ export default async function DjProfilePage({
           .map((d) => d.day) ?? [],
     },
     packages: dj.packages.map((p) => ({
+      id: p.id,
       name: p.name,
       priceFrom: p.priceFrom,
+      priceTo: p.priceTo ?? undefined,
       currency: p.currency,
+      duration: p.duration ?? undefined,
       features: p.features,
       popular: p.popular,
+      sortOrder: p.sortOrder,
     })),
     bio: dj.bio ?? "",
     specialties: dj.djTypes.map((t) => t.type),

--- a/src/app/organizer/bookings/page.tsx
+++ b/src/app/organizer/bookings/page.tsx
@@ -88,6 +88,9 @@ export default async function OrganizerBookingsPage() {
       counterpartyEmail: contactVisible ? djContactEmail : undefined,
       contactVisible,
       messages,
+      packageName: inquiry.packageName,
+      packagePrice: inquiry.packagePrice,
+      packagePriceTo: inquiry.packagePriceTo,
     };
   });
 

--- a/src/components/booking/BookingInquiryCard.tsx
+++ b/src/components/booking/BookingInquiryCard.tsx
@@ -38,6 +38,9 @@ export type BookingInquiryViewModel = {
   counterpartyEmail?: string | null;
   contactVisible: boolean;
   messages: BookingMessage[];
+  packageName?: string | null;
+  packagePrice?: number | null;
+  packagePriceTo?: number | null;
 };
 
 export type BookingInquiryCardProps = {
@@ -170,6 +173,20 @@ export function BookingInquiryCard({
               {statusTheme.label}
             </Badge>
           </div>
+          {inquiry.packageName && (
+            <div className="mt-2 rounded-lg border border-amber-500/25 bg-amber-500/10 px-3 py-2">
+              <p className="text-xs font-medium text-amber-400">
+                Package: {inquiry.packageName}
+              </p>
+              {inquiry.packagePrice && (
+                <p className="mt-1 text-xs text-gray-400">
+                  {inquiry.packagePrice.toLocaleString()}
+                  {inquiry.packagePriceTo &&
+                    ` – ${inquiry.packagePriceTo.toLocaleString()}`}
+                </p>
+              )}
+            </div>
+          )}
           {formattedEventMeta && (
             <p className="text-sm text-gray-400">{formattedEventMeta}</p>
           )}

--- a/src/components/dj-profile/BookCTA.tsx
+++ b/src/components/dj-profile/BookCTA.tsx
@@ -62,6 +62,9 @@ type FormState = {
   budgetMax: string;
   budgetCurrency: string;
   message: string;
+  packageName?: string;
+  packagePrice?: number;
+  packagePriceTo?: number;
 };
 
 const CUSTOM_VENUE_VALUE = "__CUSTOM__";
@@ -86,7 +89,11 @@ type Props = {
 };
 
 export interface BookCTARef {
-  openBookingModal: (packageName?: string, packagePrice?: number) => void;
+  openBookingModal: (
+    packageName?: string,
+    packagePrice?: number,
+    packagePriceTo?: number,
+  ) => void;
 }
 
 export const BookCTA = forwardRef<BookCTARef, Props>(
@@ -154,16 +161,33 @@ export const BookCTA = forwardRef<BookCTARef, Props>(
 
     // Expose openBookingModal function via ref
     useImperativeHandle(ref, () => ({
-      openBookingModal: (newPackageName?: string, newPackagePrice?: number) => {
+      openBookingModal: (
+        newPackageName?: string,
+        newPackagePrice?: number,
+        newPackagePriceTo?: number,
+      ) => {
         // Update form with package details
         setForm((prev) => ({
           ...prev,
-          budgetType: newPackagePrice ? "FIXED" : "NEGOTIABLE",
+          budgetType: newPackagePriceTo
+            ? "RANGE"
+            : newPackagePrice
+              ? "FIXED"
+              : "NEGOTIABLE",
           budgetMin: newPackagePrice ? String(newPackagePrice) : "",
+          budgetMax: newPackagePriceTo ? String(newPackagePriceTo) : "",
           message: newPackageName
             ? `I'm interested in the ${newPackageName} package.`
             : "",
+          packageName: newPackageName,
+          packagePrice: newPackagePrice,
+          packagePriceTo: newPackagePriceTo,
         }));
+        // Force custom venue input for package enquiries
+        if (newPackageName) {
+          setIsCustomVenue(true);
+          setVenueSelection(CUSTOM_VENUE_VALUE);
+        }
         setModal("booking");
       },
     }));
@@ -471,6 +495,9 @@ export const BookCTA = forwardRef<BookCTARef, Props>(
             form.budgetType === "RANGE" ? Number(form.budgetMax) : null,
           budgetCurrency: form.budgetCurrency || "SEK",
           message: form.message,
+          packageName: form.packageName,
+          packagePrice: form.packagePrice,
+          packagePriceTo: form.packagePriceTo,
         };
 
         const result = await submitBookingInquiry(payload);
@@ -647,6 +674,25 @@ export const BookCTA = forwardRef<BookCTARef, Props>(
                     Provide key details so {stageName} can evaluate your event
                     quickly. Contact info stays hidden until the DJ accepts.
                   </DialogDescription>
+                  {form.packageName && (
+                    <div className="mt-3 rounded-lg border border-amber-500/25 bg-amber-500/10 p-3">
+                      <p className="text-xs font-medium text-amber-400">
+                        Enquiring about: {form.packageName}
+                      </p>
+                      {form.packagePrice && (
+                        <p className="mt-1 text-xs text-gray-400">
+                          Package price: {form.budgetCurrency || "SEK"}{" "}
+                          {form.packagePrice.toLocaleString()}
+                          {form.packagePriceTo &&
+                            ` – ${form.packagePriceTo.toLocaleString()}`}
+                        </p>
+                      )}
+                      <p className="mt-2 text-[11px] text-gray-500">
+                        DJ will provide final quote based on your specific
+                        requirements
+                      </p>
+                    </div>
+                  )}
                 </DialogHeader>
 
                 <div className="grid gap-4 sm:grid-cols-2">
@@ -677,6 +723,7 @@ export const BookCTA = forwardRef<BookCTARef, Props>(
                         }))
                       }
                       required
+                      className="[color-scheme:dark]"
                     />
                   </div>
                 </div>
@@ -684,53 +731,93 @@ export const BookCTA = forwardRef<BookCTARef, Props>(
                 <div className="grid gap-4 sm:grid-cols-2">
                   <div className="flex flex-col gap-2">
                     <Label htmlFor="countryId">Country</Label>
-                    <Select
-                      value={form.countryId}
-                      onValueChange={handleCountryChange}
-                    >
-                      <SelectTrigger id="countryId">
-                        <SelectValue placeholder="Select country" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {countries.map((country) => (
-                          <SelectItem
-                            key={country.id}
-                            value={String(country.id)}
-                          >
-                            {country.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    {form.packageName ? (
+                      <div className="flex h-10 w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-gray-400">
+                        {countries.find((c) => c.id === Number(form.countryId))
+                          ?.name || "Loading..."}
+                      </div>
+                    ) : (
+                      <Select
+                        value={form.countryId}
+                        onValueChange={handleCountryChange}
+                      >
+                        <SelectTrigger id="countryId">
+                          <SelectValue placeholder="Select country" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {countries.map((country) => (
+                            <SelectItem
+                              key={country.id}
+                              value={String(country.id)}
+                            >
+                              {country.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
                   </div>
                   <div className="flex flex-col gap-2">
                     <Label htmlFor="cityId">City</Label>
-                    <Select
-                      value={form.cityId}
-                      onValueChange={handleCityChange}
-                      disabled={!form.countryId || isLoadingCities}
-                    >
-                      <SelectTrigger id="cityId">
-                        <SelectValue
-                          placeholder={
-                            isLoadingCities
-                              ? "Loading…"
-                              : form.countryId
-                                ? "Select city"
-                                : "Select country first"
-                          }
-                        />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {cities.map((city) => (
-                          <SelectItem key={city.id} value={String(city.id)}>
-                            {city.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    {form.packageName ? (
+                      <div className="flex h-10 w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-gray-400">
+                        {cities.find((c) => c.id === Number(form.cityId))
+                          ?.name || "Loading..."}
+                      </div>
+                    ) : (
+                      <Select
+                        value={form.cityId}
+                        onValueChange={handleCityChange}
+                        disabled={!form.countryId || isLoadingCities}
+                      >
+                        <SelectTrigger id="cityId">
+                          <SelectValue
+                            placeholder={
+                              isLoadingCities
+                                ? "Loading…"
+                                : form.countryId
+                                  ? "Select city"
+                                  : "Select country first"
+                            }
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {cities.map((city) => (
+                            <SelectItem key={city.id} value={String(city.id)}>
+                              {city.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
                   </div>
                 </div>
+
+                {form.packageName && (
+                  <p className="text-[11px] text-gray-500">
+                    If you want the DJ to play in another city,{" "}
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setForm((prev) => ({
+                          ...prev,
+                          packageName: undefined,
+                          packagePrice: undefined,
+                          packagePriceTo: undefined,
+                          budgetType: "NEGOTIABLE",
+                          budgetMin: "",
+                          budgetMax: "",
+                          message: "",
+                        }));
+                        setIsCustomVenue(false);
+                        setVenueSelection("");
+                      }}
+                      className="text-h_red hover:text-h_redDark cursor-pointer underline underline-offset-2"
+                    >
+                      use the general booking form
+                    </button>
+                  </p>
+                )}
 
                 <div className="flex flex-col gap-2">
                   <Label htmlFor="venue">Venue</Label>
@@ -806,105 +893,108 @@ export const BookCTA = forwardRef<BookCTARef, Props>(
                   />
                 </div>
 
-                <div className="flex flex-col gap-2">
-                  <Label>Budget</Label>
-                  <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-                    {BUDGET_OPTIONS.map((opt) => {
-                      const active = form.budgetType === opt.value;
-                      return (
-                        <button
-                          key={opt.value}
-                          type="button"
-                          onClick={() =>
-                            setForm((prev) => ({
-                              ...prev,
-                              budgetType: opt.value,
-                              budgetMin:
-                                opt.value === "NEGOTIABLE" ||
-                                opt.value === "TBA"
-                                  ? ""
-                                  : prev.budgetMin,
-                              budgetMax:
-                                opt.value === "RANGE" ? prev.budgetMax : "",
-                            }))
-                          }
-                          className={cn(
-                            "flex flex-col gap-0.5 rounded-lg border px-3 py-2.5 text-left transition-colors",
-                            active
-                              ? "border-white/40 bg-white/10 text-white"
-                              : "border-white/10 text-gray-400 hover:border-white/20 hover:text-gray-200",
-                          )}
-                        >
-                          <span className="text-sm font-medium">
-                            {opt.label}
-                          </span>
-                          <span className="text-[11px] text-gray-500">
-                            {opt.hint}
-                          </span>
-                        </button>
-                      );
-                    })}
-                  </div>
+                {!form.packageName && (
+                  <div className="flex flex-col gap-2">
+                    <Label>Budget</Label>
+                    <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                      {BUDGET_OPTIONS.map((opt) => {
+                        const active = form.budgetType === opt.value;
+                        return (
+                          <button
+                            key={opt.value}
+                            type="button"
+                            onClick={() =>
+                              setForm((prev) => ({
+                                ...prev,
+                                budgetType: opt.value,
+                                budgetMin:
+                                  opt.value === "NEGOTIABLE" ||
+                                  opt.value === "TBA"
+                                    ? ""
+                                    : prev.budgetMin,
+                                budgetMax:
+                                  opt.value === "RANGE" ? prev.budgetMax : "",
+                              }))
+                            }
+                            className={cn(
+                              "flex flex-col gap-0.5 rounded-lg border px-3 py-2.5 text-left transition-colors",
+                              active
+                                ? "border-white/40 bg-white/10 text-white"
+                                : "border-white/10 text-gray-400 hover:border-white/20 hover:text-gray-200",
+                            )}
+                          >
+                            <span className="text-sm font-medium">
+                              {opt.label}
+                            </span>
+                            <span className="text-[11px] text-gray-500">
+                              {opt.hint}
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </div>
 
-                  {(form.budgetType === "FIXED" ||
-                    form.budgetType === "RANGE") && (
-                    <div className="mt-2 grid gap-3 sm:grid-cols-3">
-                      <div className="flex flex-col gap-2">
-                        <Label htmlFor="budgetMin">
-                          {form.budgetType === "FIXED"
-                            ? "Amount"
-                            : "Min amount"}
-                        </Label>
-                        <Input
-                          id="budgetMin"
-                          type="number"
-                          min={0}
-                          value={form.budgetMin}
-                          onChange={(event) =>
-                            setForm((prev) => ({
-                              ...prev,
-                              budgetMin: event.target.value,
-                            }))
-                          }
-                          required
-                        />
-                      </div>
-                      {form.budgetType === "RANGE" && (
+                    {(form.budgetType === "FIXED" ||
+                      form.budgetType === "RANGE") && (
+                      <div className="mt-2 grid gap-3 sm:grid-cols-3">
                         <div className="flex flex-col gap-2">
-                          <Label htmlFor="budgetMax">Max amount</Label>
+                          <Label htmlFor="budgetMin">
+                            {form.budgetType === "FIXED"
+                              ? "Amount"
+                              : "Min amount"}
+                          </Label>
                           <Input
-                            id="budgetMax"
+                            id="budgetMin"
                             type="number"
                             min={0}
-                            value={form.budgetMax}
+                            value={form.budgetMin}
                             onChange={(event) =>
                               setForm((prev) => ({
                                 ...prev,
-                                budgetMax: event.target.value,
+                                budgetMin: event.target.value,
                               }))
                             }
                             required
                           />
                         </div>
-                      )}
-                      <div className="flex flex-col gap-2">
-                        <Label htmlFor="budgetCurrency">Currency</Label>
-                        <Input
-                          id="budgetCurrency"
-                          value={form.budgetCurrency}
-                          onChange={(event) =>
-                            setForm((prev) => ({
-                              ...prev,
-                              budgetCurrency: event.target.value.toUpperCase(),
-                            }))
-                          }
-                          maxLength={10}
-                          required
-                        />
+                        {form.budgetType === "RANGE" && (
+                          <div className="flex flex-col gap-2">
+                            <Label htmlFor="budgetMax">Max amount</Label>
+                            <Input
+                              id="budgetMax"
+                              type="number"
+                              min={0}
+                              value={form.budgetMax}
+                              onChange={(event) =>
+                                setForm((prev) => ({
+                                  ...prev,
+                                  budgetMax: event.target.value,
+                                }))
+                              }
+                              required
+                            />
+                          </div>
+                        )}
+                        <div className="flex flex-col gap-2">
+                          <Label htmlFor="budgetCurrency">Currency</Label>
+                          <Input
+                            id="budgetCurrency"
+                            value={form.budgetCurrency}
+                            onChange={(event) =>
+                              setForm((prev) => ({
+                                ...prev,
+                                budgetCurrency:
+                                  event.target.value.toUpperCase(),
+                              }))
+                            }
+                            maxLength={10}
+                            required
+                          />
+                        </div>
                       </div>
-                    </div>
-                  )}
-                </div>
+                    )}
+                  </div>
+                )}
 
                 <div className="flex flex-col gap-2">
                   <Label htmlFor="message">Message</Label>

--- a/src/components/dj-profile/BookingPackages.tsx
+++ b/src/components/dj-profile/BookingPackages.tsx
@@ -8,6 +8,7 @@ import { CircleCheck } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { LucideIcon } from "lucide-react";
 import { getCurrencyByCode } from "@/config/currencies";
+import { toast } from "sonner";
 
 type Package = {
   id: number;
@@ -24,13 +25,19 @@ type Package = {
 type Props = {
   packages: Package[];
   onEnquire?: (packageName: string, priceFrom: number) => void;
-  openBookingModal?: (packageName?: string, packagePrice?: number) => void;
+  openBookingModal?: (
+    packageName?: string,
+    packagePrice?: number,
+    packagePriceTo?: number,
+  ) => void;
+  viewerRole?: "guest" | "fan" | "organizer" | "admin" | "dj-owner";
 };
 
 export default function BookingPackages({
   packages,
   onEnquire,
   openBookingModal,
+  viewerRole = "guest",
 }: Props) {
   if (!packages || packages.length === 0) {
     return null;
@@ -59,61 +66,90 @@ export default function BookingPackages({
   };
 
   return (
-    <section>
-      <SectionHeading sub="Tailored options for every event type">
-        Booking Packages
-      </SectionHeading>
-      <div className="grid gap-4 sm:grid-cols-3">
-        {packages.map((pkg) => (
-          <Card
-            key={pkg.id}
-            className={cn(
-              "relative flex flex-col gap-0 overflow-hidden border-white/8 p-5",
-              pkg.popular
-                ? "to-h_blackLight/30 border-amber-500/30 bg-linear-to-b from-amber-500/10"
-                : "bg-h_blackLight/30",
-            )}
-          >
-            {pkg.popular && (
-              <Badge className="absolute top-3 right-3 border-amber-500/25 bg-amber-500/15 text-[11px] text-amber-400">
-                Most Popular
-              </Badge>
-            )}
-            {pkg.icon && (
-              <div className="bg-h_red/10 border-h_red/20 mb-3 flex size-10 items-center justify-center rounded-lg border">
-                <pkg.icon className="text-h_red h-4 w-4" />
-              </div>
-            )}
-            <p className="text-sm font-semibold text-white">{pkg.name}</p>
-            <p className="text-h_red mt-1 text-lg font-bold">
-              {formatPrice(pkg.priceFrom, pkg.currency, pkg.priceTo)}
+    <div className="grid gap-4 sm:grid-cols-3">
+      {packages.map((pkg, idx) => (
+        <Card
+          key={`${pkg.id}-${idx}`}
+          className={cn(
+            "relative flex flex-col gap-0 overflow-hidden border-white/8 p-5",
+            pkg.popular
+              ? "to-h_blackLight/30 border-amber-500/30 bg-linear-to-b from-amber-500/10"
+              : "bg-h_blackLight/30",
+          )}
+        >
+          {pkg.popular && (
+            <Badge className="absolute top-3 right-3 border-amber-500/25 bg-amber-500/15 text-[11px] text-amber-400">
+              Most Popular
+            </Badge>
+          )}
+          {pkg.icon && (
+            <div className="bg-h_red/10 border-h_red/20 mb-3 flex size-10 items-center justify-center rounded-lg border">
+              <pkg.icon className="text-h_red h-4 w-4" />
+            </div>
+          )}
+          <p className="text-sm font-semibold text-white">{pkg.name}</p>
+          <p className="text-h_red mt-1 text-lg font-bold">
+            {formatPrice(pkg.priceFrom, pkg.currency, pkg.priceTo)}
+          </p>
+          {pkg.duration && (
+            <p className="mb-3 text-xs text-gray-500">
+              {formatDuration(pkg.duration)}
             </p>
-            {pkg.duration && (
-              <p className="mb-3 text-xs text-gray-500">
-                {formatDuration(pkg.duration)}
-              </p>
-            )}
-            <ul className="flex flex-1 flex-col gap-1.5">
-              {pkg.features.map((feature) => (
-                <li
-                  key={feature}
-                  className="flex items-center gap-1.5 text-xs text-gray-400"
-                >
-                  <CircleCheck className="h-3 w-3 shrink-0 text-emerald-500" />
-                  {feature}
-                </li>
-              ))}
-            </ul>
+          )}
+          <ul className="flex flex-1 flex-col gap-1.5">
+            {pkg.features.map((feature, idx) => (
+              <li
+                key={`${pkg.id}-feature-${idx}`}
+                className="flex items-center gap-1.5 text-xs text-gray-400"
+              >
+                <CircleCheck className="h-3 w-3 shrink-0 text-emerald-500" />
+                {feature}
+              </li>
+            ))}
+          </ul>
+          {viewerRole === "dj-owner" ? null : viewerRole ===
+            "guest" ? null : viewerRole === "fan" ? (
             <Button
               className="bg-h_red hover:bg-h_redDark mt-4 w-full font-semibold text-white"
               size="sm"
-              onClick={() => openBookingModal?.(pkg.name, pkg.priceFrom)}
+              onClick={() => {
+                toast.error(
+                  "You must be an organizer to enquire about bookings",
+                  {
+                    description: (
+                      <div className="mt-2">
+                        <a
+                          href="/become-organizer"
+                          className="text-white underline underline-offset-2 hover:text-gray-200"
+                        >
+                          Become an organizer
+                        </a>
+                      </div>
+                    ),
+                    duration: 5000,
+                  },
+                );
+              }}
             >
               Enquire
             </Button>
-          </Card>
-        ))}
-      </div>
-    </section>
+          ) : (
+            <Button
+              className="bg-h_red hover:bg-h_redDark mt-4 w-full font-semibold text-white"
+              size="sm"
+              onClick={() =>
+                openBookingModal?.(
+                  pkg.name,
+                  pkg.priceFrom,
+                  pkg.priceTo || undefined,
+                )
+              }
+            >
+              Enquire
+            </Button>
+          )}
+        </Card>
+      ))}
+    </div>
   );
 }

--- a/src/components/dj-profile/DjProfilePremium.tsx
+++ b/src/components/dj-profile/DjProfilePremium.tsx
@@ -22,6 +22,7 @@ import {
   MapPin,
   Star,
   Plus,
+  Pencil,
 } from "lucide-react";
 import type { DjDemoData, ViewMode } from "@/types/dj-demo";
 import { DjProfileHero } from "@/components/dj-profile/DjProfileHero";
@@ -275,17 +276,19 @@ export default function DjProfilePremium({
       sortOrder: number;
     }>
   >(
-    (djData?.packages || []).map((p: any) => ({
-      id: p.id || 0,
-      name: p.name || "",
-      priceFrom: p.priceFrom || 0,
-      priceTo: p.priceTo || null,
-      currency: p.currency || "USD",
-      duration: p.duration || null,
-      features: p.features || [],
-      popular: p.popular || false,
-      sortOrder: p.sortOrder || 0,
-    })),
+    (djData?.packages || [])
+      .filter((p: any) => p.id != null && p.id !== undefined)
+      .map((p: any) => ({
+        id: p.id,
+        name: p.name || "",
+        priceFrom: p.priceFrom || 0,
+        priceTo: p.priceTo || null,
+        currency: p.currency || "USD",
+        duration: p.duration || null,
+        features: p.features || [],
+        popular: p.popular || false,
+        sortOrder: p.sortOrder || 0,
+      })),
   );
 
   async function handleVenueSave(newVenues: typeof venues) {
@@ -410,6 +413,10 @@ export default function DjProfilePremium({
 
       // Update modified packages
       for (const pkg of packagesToUpdate) {
+        // Skip packages with invalid IDs
+        if (!pkg.id || pkg.id === undefined || pkg.id === null) {
+          continue;
+        }
         const formData = new FormData();
         formData.append("name", pkg.name.trim());
         formData.append("priceFrom", String(pkg.priceFrom));
@@ -1033,25 +1040,52 @@ export default function DjProfilePremium({
             {/* ── BOOKING PACKAGES ── */}
             {(packages.length > 0 || isOwner) && (
               <section>
-                <SectionHeading sub="Tailored options for every event type">
-                  Booking Packages
-                </SectionHeading>
+                <div className="mb-5 flex items-center justify-between">
+                  <SectionHeading sub="Tailored options for every event type">
+                    Booking Packages
+                  </SectionHeading>
+                  {isOwner && packages.length > 0 && (
+                    <Button
+                      onClick={() => setIsPackageModalOpen(true)}
+                      variant="ghost"
+                      size="sm"
+                      className="text-xs text-gray-400 hover:text-white"
+                    >
+                      <Pencil className="mr-1.5 h-3 w-3" />
+                      Edit
+                    </Button>
+                  )}
+                </div>
                 {packages.length > 0 ? (
                   <BookingPackages
-                    packages={packages.map((p) => ({
-                      id: p.id,
-                      name: p.name,
-                      priceFrom: p.priceFrom,
-                      priceTo: p.priceTo,
-                      currency: p.currency,
-                      duration: p.duration,
-                      features: p.features,
-                      popular: p.popular,
-                    }))}
-                    openBookingModal={(packageName, packagePrice) =>
+                    packages={packages
+                      .sort((a, b) => {
+                        // Popular packages first
+                        if (a.popular && !b.popular) return -1;
+                        if (!a.popular && b.popular) return 1;
+                        // Then by sortOrder
+                        return a.sortOrder - b.sortOrder;
+                      })
+                      .map((p) => ({
+                        id: p.id,
+                        name: p.name,
+                        priceFrom: p.priceFrom,
+                        priceTo: p.priceTo,
+                        currency: p.currency,
+                        duration: p.duration,
+                        features: p.features,
+                        popular: p.popular,
+                      }))}
+                    viewerRole={bookingContext.role}
+                    openBookingModal={(
+                      packageName,
+                      packagePrice,
+                      packagePriceTo,
+                    ) =>
                       bookCTARef.current?.openBookingModal(
                         packageName,
                         packagePrice,
+                        packagePriceTo,
                       )
                     }
                   />

--- a/src/components/dj-profile/PackageModal.tsx
+++ b/src/components/dj-profile/PackageModal.tsx
@@ -194,7 +194,7 @@ export default function PackageModal({
         <div className="flex flex-col gap-4">
           {packages.map((pkg, index) => (
             <div
-              key={pkg.id || index}
+              key={`${pkg.id || 0}-${index}`}
               className="flex flex-col gap-3 rounded-lg border border-white/10 bg-white/5 p-4"
             >
               <div className="flex items-center justify-between">

--- a/src/lib/actions/booking-inquiry.ts
+++ b/src/lib/actions/booking-inquiry.ts
@@ -48,6 +48,9 @@ const submitBookingInquirySchema = z
     budgetMax: z.number().int().nonnegative().max(1_000_000).nullable(),
     budgetCurrency: z.string().trim().min(2).max(10),
     message: z.string().trim().min(50).max(1500),
+    packageName: z.string().trim().max(100).optional(),
+    packagePrice: z.number().int().nonnegative().max(1_000_000).nullable(),
+    packagePriceTo: z.number().int().nonnegative().max(1_000_000).nullable(),
   })
   .superRefine((value, ctx) => {
     const eventDate = new Date(value.eventDate);
@@ -168,6 +171,20 @@ async function getOrganizerProfile(userId: string) {
       deletedAt: true,
       displayName: true,
       contactEmail: true,
+      cityId: true,
+      city: {
+        select: {
+          id: true,
+          name: true,
+          countryId: true,
+          country: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+      },
     },
   });
 }
@@ -183,6 +200,20 @@ async function getDjProfileForInquiry(djProfileId: number) {
       bookingEmail: true,
       userId: true,
       user: { select: { id: true, email: true, name: true } },
+      cityId: true,
+      city: {
+        select: {
+          id: true,
+          name: true,
+          countryId: true,
+          country: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+      },
     },
   });
 }
@@ -379,6 +410,9 @@ export async function submitBookingInquiry(
         budgetMax,
         budgetCurrency: budgetCurrency.toUpperCase(),
         message: payload.message,
+        packageName: payload.packageName,
+        packagePrice: payload.packagePrice,
+        packagePriceTo: payload.packagePriceTo,
       } satisfies Record<string, unknown>;
 
       const locationCreateData = {
@@ -473,6 +507,9 @@ export async function submitBookingInquiry(
           .filter(Boolean)
           .join(", "),
         ctaUrl: `${BASE_URL}/dashboard/dj/bookings?inquiry=${createdInquiry.id}`,
+        packageName: payload.packageName,
+        packagePrice: payload.packagePrice,
+        packagePriceTo: payload.packagePriceTo,
       }),
     });
   }

--- a/src/lib/actions/dj-packages.ts
+++ b/src/lib/actions/dj-packages.ts
@@ -33,13 +33,10 @@ export async function createDjPackage(
   const priceTo = priceToRaw ? parseInt(priceToRaw as string, 10) : null;
   const currency = (formData.get("currency") as string)?.trim() || "USD";
   const duration = (formData.get("duration") as string)?.trim() || null;
-  const featuresRaw = (formData.get("features") as string)?.trim();
-  const features = featuresRaw
-    ? featuresRaw
-        .split("\n")
-        .map((f) => f.trim())
-        .filter(Boolean)
-    : [];
+  const features = formData
+    .getAll("features")
+    .map((f) => String(f).trim())
+    .filter(Boolean);
   const popular = formData.get("popular") === "true";
 
   if (!name || isNaN(priceFrom)) {
@@ -86,13 +83,10 @@ export async function updateDjPackage(
   const priceToRaw = formData.get("priceTo");
   const currency = (formData.get("currency") as string)?.trim() || null;
   const duration = (formData.get("duration") as string)?.trim() || null;
-  const featuresRaw = (formData.get("features") as string)?.trim();
-  const features = featuresRaw
-    ? featuresRaw
-        .split("\n")
-        .map((f) => f.trim())
-        .filter(Boolean)
-    : undefined;
+  const features = formData
+    .getAll("features")
+    .map((f) => String(f).trim())
+    .filter(Boolean);
   const popular = formData.get("popular");
 
   const data: Record<string, unknown> = {};

--- a/src/lib/email/templates/bookingInquiryReceived.ts
+++ b/src/lib/email/templates/bookingInquiryReceived.ts
@@ -9,6 +9,9 @@ export function bookingInquiryReceivedHtml({
   eventDate,
   location,
   ctaUrl,
+  packageName,
+  packagePrice,
+  packagePriceTo,
 }: {
   djName: string;
   organizerName: string;
@@ -16,12 +19,20 @@ export function bookingInquiryReceivedHtml({
   eventDate?: string | null;
   location?: string | null;
   ctaUrl: string;
+  packageName?: string | null;
+  packagePrice?: number | null;
+  packagePriceTo?: number | null;
 }): string {
   const safeDj = escapeHtml(djName);
   const safeOrganizer = escapeHtml(organizerName);
   const safeEvent = escapeHtml(eventName);
   const safeDate = eventDate ? escapeHtml(eventDate) : null;
   const safeLocation = location ? escapeHtml(location) : null;
+  const safePackageName = packageName ? escapeHtml(packageName) : null;
+  const safePackagePrice = packagePrice ? packagePrice.toLocaleString() : null;
+  const safePackagePriceTo = packagePriceTo
+    ? packagePriceTo.toLocaleString()
+    : null;
 
   return baseLayout(`
     <h1 style="color:#ffffff;font-size:24px;font-weight:700;margin:0 0 12px;">
@@ -42,6 +53,19 @@ export function bookingInquiryReceivedHtml({
       safeLocation
         ? `<p style="color:#9ca3af;font-size:15px;line-height:1.7;margin:0 0 18px;">
             Location: <strong style="color:#d1d5db;">${safeLocation}</strong>
+          </p>`
+        : ""
+    }
+    ${
+      safePackageName
+        ? `<p style="color:#9ca3af;font-size:15px;line-height:1.7;margin:0 0 18px;">
+            Package: <strong style="color:#d1d5db;">${safePackageName}</strong>${
+              safePackagePrice
+                ? ` (${safePackagePrice}${
+                    safePackagePriceTo ? ` – ${safePackagePriceTo}` : ""
+                  })`
+                : ""
+            }
           </p>`
         : ""
     }

--- a/src/types/booking.ts
+++ b/src/types/booking.ts
@@ -10,6 +10,8 @@ export interface BookingViewerContext {
   isAuthenticated: boolean;
   organizerDisplayName?: string | null;
   organizerContactEmail?: string | null;
+  organizerCityId?: number | null;
+  organizerCityName?: string | null;
 }
 
 export type CountryOption = {


### PR DESCRIPTION
- Add packageName, packagePrice, and packagePriceTo fields to BookingInquiry schema
- Pre-populate booking form with package details when booking from package card
- Display selected package info in booking modal with amber highlight badge
- Lock country/city fields to organizer's location for package enquiries
- Force custom venue input when booking specific package
- Show package details in booking inquiry cards for both DJ and organizer views