### PR TITLE
feat: add production coming-soon mask

### DIFF
--- a/src/app/coming-soon/page.tsx
+++ b/src/app/coming-soon/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import ComingSoonShell from "@/components/coming-soon/ComingSoonShell";
+
+export const metadata: Metadata = {
+  title: "Coming Soon | DJcovery",
+  description:
+    "DJcovery is getting a brand new home. Stay tuned for something special.",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function ComingSoonPage() {
+  return (
+    <ComingSoonShell>
+      <div className="flex flex-col items-center justify-center text-center">
+        <Image
+          src="/dj_logo-new.svg"
+          alt="DJcovery"
+          width={180}
+          height={44}
+          priority
+          className="mb-8"
+        />
+        <h1 className="font-heading text-4xl font-bold text-white sm:text-5xl md:text-6xl">
+          Coming Soon
+        </h1>
+        <p className="mt-4 max-w-md text-lg text-gray-400">
+          DJcovery is getting a brand new home. We&apos;re putting the finishing
+          touches on something special for DJs and event organizers.
+        </p>
+        <div className="mt-10 flex items-center gap-2 text-sm text-gray-500">
+          <span className="bg-h_red inline-block h-2 w-2 animate-pulse rounded-full" />
+          Stay tuned
+        </div>
+      </div>
+    </ComingSoonShell>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,7 @@ import PublicShell from "@/components/PublicShell";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import MobileBottomNavServer from "@/components/MobileBottomNavServer";
+import { isComingSoonRoute } from "@/lib/coming-soon";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -64,33 +65,41 @@ export const metadata: Metadata = {
       },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const isComingSoon = await isComingSoonRoute();
+
   return (
     <html
       lang="en"
       className={cn(inter.variable, sora.variable, "font-sans", "dark")}
     >
       <body className={inter.className}>
-        <NavigationProgress />
-        <PublicShell
-          navbar={<Navbar />}
-          footer={<Footer />}
-          mobileNav={<MobileBottomNavServer />}
-        >
-          {children}
-        </PublicShell>
-        <Toaster
-          position="bottom-right"
-          theme="dark"
-          richColors
-          closeButton
-          offset={{ bottom: 80 }}
-        />
-        <CookieBanner />
+        {isComingSoon ? (
+          children
+        ) : (
+          <>
+            <NavigationProgress />
+            <PublicShell
+              navbar={<Navbar />}
+              footer={<Footer />}
+              mobileNav={<MobileBottomNavServer />}
+            >
+              {children}
+            </PublicShell>
+            <Toaster
+              position="bottom-right"
+              theme="dark"
+              richColors
+              closeButton
+              offset={{ bottom: 80 }}
+            />
+            <CookieBanner />
+          </>
+        )}
       </body>
     </html>
   );

--- a/src/components/coming-soon/ComingSoonShell.tsx
+++ b/src/components/coming-soon/ComingSoonShell.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+
+export default function ComingSoonShell({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-[#050505] px-6 py-20">
+      {children}
+    </div>
+  );
+}

--- a/src/lib/coming-soon.ts
+++ b/src/lib/coming-soon.ts
@@ -1,0 +1,15 @@
+import { headers } from "next/headers";
+
+/**
+ * Returns true when the request is for the /coming-soon placeholder page.
+ * The middleware sets the x-is-coming-soon header for this route so the root
+ * layout can render a clean page without the public navbar/footer shell.
+ */
+export async function isComingSoonRoute(): Promise<boolean> {
+  const headersList = await headers();
+  return (
+    headersList.get("x-is-coming-soon") === "true" ||
+    headersList.get("x-invoke-path") === "/coming-soon" ||
+    headersList.get("x-pathname") === "/coming-soon"
+  );
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,15 +4,15 @@ import { indexingEnabled } from "./lib/seo/indexing";
 
 const PRE_LAUNCH_MODE = process.env.PRE_LAUNCH_MODE === "true";
 
-// Paths that remain accessible during pre-launch (public landing, auth, legal, admin, api)
+const isProduction =
+  process.env.VERCEL_ENV === "production" ||
+  process.env.NEXT_PUBLIC_APP_ENV === "production";
+
+// Paths that remain accessible when the production site is masked behind the
+// coming-soon placeholder. Auth paths and /admin stay reachable so the team can
+// still sign in; everything else redirects to /coming-soon.
 const ALWAYS_PUBLIC_PATHS = [
-  "/",
-  "/about",
-  "/contact",
-  "/faq",
-  "/terms",
-  "/privacy",
-  "/founding-djs",
+  "/coming-soon",
   "/sign-in",
   "/sign-up",
   "/forgot-password",
@@ -30,10 +30,14 @@ function isAlwaysPublic(pathname: string): boolean {
 export async function proxy(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
 
-  // ── Pre-launch gate: block all platform routes in production ─────────────
-  if (PRE_LAUNCH_MODE && !isAlwaysPublic(request.nextUrl.pathname)) {
+  // ── Pre-launch gate: mask the platform in production ──────────────────
+  if (
+    PRE_LAUNCH_MODE &&
+    isProduction &&
+    !isAlwaysPublic(request.nextUrl.pathname)
+  ) {
     const url = request.nextUrl.clone();
-    url.pathname = "/";
+    url.pathname = "/coming-soon";
     return NextResponse.redirect(url);
   }
 
@@ -97,6 +101,11 @@ export async function proxy(request: NextRequest) {
     );
   }
   // noindexing code end here
+
+  // Mark the placeholder page so the root layout hides the public shell.
+  if (request.nextUrl.pathname === "/coming-soon") {
+    supabaseResponse.headers.set("x-is-coming-soon", "true");
+  }
 
   // Content Security Policy
   const cspHeader = [


### PR DESCRIPTION
- Add /coming-soon page with branded DJcovery placeholder
- Root layout skips navbar/footer/toaster/cookie-banner for /coming-soon
- Proxy middleware redirects all routes to /coming-soon when PRE_LAUNCH_MODE=true in production
- Auth paths and /admin remain accessible during pre-launch
- Static assets and API routes continue to work

To activate in production: set PRE_LAUNCH_MODE=true in Vercel env vars