### PR TITLE
feat(dj-events): implement events page with upcoming/past/drafts tabs…

### DIFF
--- a/src/app/dj/applications/loading.tsx
+++ b/src/app/dj/applications/loading.tsx
@@ -1,0 +1,48 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DjApplicationsLoading() {
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="mb-2 space-y-2">
+        <Skeleton className="h-7 w-40 rounded" />
+        <Skeleton className="h-4 w-48 rounded" />
+      </div>
+
+      {/* Sections */}
+      {Array.from({ length: 2 }).map((_, sectionIndex) => (
+        <section key={sectionIndex}>
+          <Skeleton className="mb-3 h-3 w-28 rounded" />
+          <div className="flex flex-col gap-3">
+            {Array.from({ length: 2 }).map((_, i) => (
+              <ApplicationRowSkeleton key={i} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function ApplicationRowSkeleton() {
+  return (
+    <div className="flex items-start gap-4 rounded-xl border border-white/10 bg-white/5 p-4">
+      <Skeleton className="mt-0.5 h-9 w-9 shrink-0 rounded-full" />
+      <div className="min-w-0 flex-1 space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Skeleton className="h-4 w-40 rounded" />
+          <Skeleton className="h-4 w-16 rounded" />
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <Skeleton className="h-3 w-20 rounded" />
+          <Skeleton className="h-3 w-24 rounded" />
+          <Skeleton className="h-3 w-28 rounded" />
+        </div>
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-3 w-24 rounded" />
+          <Skeleton className="h-3 w-16 rounded" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dj/bookings/loading.tsx
+++ b/src/app/dj/bookings/loading.tsx
@@ -1,0 +1,71 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DjBookingsLoading() {
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="mb-2 space-y-2">
+        <Skeleton className="h-7 w-40 rounded" />
+        <Skeleton className="h-4 w-3/4 max-w-xl rounded" />
+      </div>
+
+      {/* Tabs */}
+      <div className="flex w-fit gap-1 rounded-lg bg-white/5 p-0.75">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-7 w-28 rounded-md" />
+        ))}
+      </div>
+
+      {/* Booking inquiry cards */}
+      <div className="space-y-5">
+        {Array.from({ length: 2 }).map((_, i) => (
+          <BookingInquirySkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function BookingInquirySkeleton() {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 p-5 shadow-[0_0_30px_rgba(0,0,0,0.35)]">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <Skeleton className="h-5 w-40 rounded" />
+            <Skeleton className="h-5 w-16 rounded" />
+          </div>
+          <Skeleton className="h-14 w-56 rounded-lg" />
+          <Skeleton className="h-4 w-64 rounded" />
+          <Skeleton className="h-3 w-32 rounded" />
+        </div>
+        <Skeleton className="h-3 w-28 rounded" />
+      </div>
+
+      {/* Conversation */}
+      <div className="mt-5 space-y-3">
+        <Skeleton className="h-4 w-24 rounded" />
+        <Skeleton className="h-16 w-3/4 rounded-lg" />
+      </div>
+
+      {/* Respond section */}
+      <div className="mt-5 rounded-xl border border-white/10 bg-white/3 p-4">
+        <Skeleton className="mb-3 h-4 w-32 rounded" />
+        <Skeleton className="mb-3 h-20 w-full rounded-lg" />
+        <div className="flex gap-2">
+          <Skeleton className="h-9 w-20 rounded" />
+          <Skeleton className="h-9 w-20 rounded" />
+        </div>
+      </div>
+
+      {/* Message section */}
+      <div className="mt-4 rounded-xl border border-white/10 bg-white/3 p-4">
+        <Skeleton className="mb-3 h-4 w-28 rounded" />
+        <Skeleton className="mb-3 h-20 w-full rounded-lg" />
+        <div className="flex justify-end">
+          <Skeleton className="h-9 w-28 rounded" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dj/events/loading.tsx
+++ b/src/app/dj/events/loading.tsx
@@ -1,0 +1,69 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DjEventsLoading() {
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-7 w-32 rounded" />
+          <Skeleton className="h-4 w-72 rounded" />
+        </div>
+        <Skeleton className="mt-2 h-9 w-32 rounded sm:mt-0" />
+      </div>
+
+      {/* Tabs */}
+      <div className="flex w-fit gap-1 rounded-lg bg-white/5 p-0.75">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-7 w-28 rounded-md" />
+        ))}
+      </div>
+
+      {/* Events grid */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <EventCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EventCardSkeleton() {
+  return (
+    <div className="flex flex-col overflow-hidden rounded-xl border border-white/10 bg-white/5">
+      <div className="relative h-40 overflow-hidden">
+        <Skeleton className="h-full w-full rounded-none" />
+        <div className="absolute top-3 left-3 flex gap-1.5">
+          <Skeleton className="h-5 w-16 rounded-full" />
+          <Skeleton className="h-5 w-20 rounded-full" />
+        </div>
+        <div className="absolute top-3 right-3">
+          <Skeleton className="h-7 w-16 rounded" />
+        </div>
+        <div className="absolute right-3 bottom-3 left-3">
+          <Skeleton className="h-5 w-3/4 rounded" />
+        </div>
+      </div>
+
+      <div className="flex flex-1 flex-col gap-2 p-4">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-5 w-20 rounded" />
+          <Skeleton className="h-4 w-12 rounded" />
+        </div>
+
+        <Skeleton className="h-4 w-32 rounded" />
+        <Skeleton className="h-4 w-48 rounded" />
+
+        <div className="mt-auto flex items-center justify-between border-t border-white/5 pt-3">
+          <div className="flex gap-3">
+            <Skeleton className="h-3.5 w-14 rounded" />
+            <Skeleton className="h-3.5 w-14 rounded" />
+            <Skeleton className="h-3.5 w-14 rounded" />
+          </div>
+          <Skeleton className="h-3.5 w-16 rounded" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dj/events/new/page.tsx
+++ b/src/app/dj/events/new/page.tsx
@@ -1,0 +1,43 @@
+import { redirect } from "next/navigation";
+import { Metadata } from "next";
+import { createClient } from "@/lib/supabase/server";
+import prisma from "@/lib/client";
+import { getCountries } from "@/lib/actions/locations";
+import { EventForm } from "@/components/events/EventForm";
+
+export const metadata: Metadata = { title: "Create Event — DJcovery" };
+
+export default async function CreateEventPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/sign-in");
+
+  const djProfile = await prisma.djProfile.findUnique({
+    where: { userId: user.id },
+    select: { id: true, countryId: true, cityId: true },
+  });
+  if (!djProfile) redirect("/become-dj");
+
+  const countries = await getCountries();
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold text-white">Create Event</h1>
+        <p className="text-sm text-gray-400">
+          Publish a new event and showcase it on your DJ profile.
+        </p>
+      </div>
+      <EventForm
+        mode="create"
+        countries={countries}
+        djDefaults={{
+          countryId: djProfile.countryId?.toString(),
+          cityId: djProfile.cityId?.toString(),
+        }}
+      />
+    </div>
+  );
+}

--- a/src/app/dj/events/page.tsx
+++ b/src/app/dj/events/page.tsx
@@ -1,14 +1,142 @@
-import { Card, CardContent } from "@/components/ui/card";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { Plus } from "lucide-react";
+import { createClient } from "@/lib/supabase/server";
+import prisma from "@/lib/client";
+import { Button } from "@/components/ui/button";
+import DjEventsTabs from "@/components/dj/DjEventsTabs";
+
+export const metadata = { title: "My Events — DJcovery" };
 
 export default async function DjEventsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/sign-in");
+
+  const djProfile = await prisma.djProfile.findUnique({
+    where: { userId: user.id },
+    select: { id: true, slug: true, stageName: true },
+  });
+  if (!djProfile) redirect("/become-dj");
+
+  const events = await prisma.event.findMany({
+    where: {
+      deletedAt: null,
+      OR: [
+        { ownerDjId: djProfile.id },
+        { participants: { some: { djProfileId: djProfile.id } } },
+      ],
+    },
+    orderBy: { startDate: "desc" },
+    select: {
+      id: true,
+      slug: true,
+      title: true,
+      eventType: true,
+      category: true,
+      status: true,
+      startDate: true,
+      endDate: true,
+      venue: true,
+      posterUrl: true,
+      featured: true,
+      viewCount: true,
+      city: { select: { name: true } },
+      country: { select: { name: true } },
+      ownerDj: { select: { id: true, slug: true, stageName: true } },
+      participants: {
+        select: {
+          role: true,
+          djProfile: { select: { id: true, stageName: true, slug: true } },
+        },
+      },
+      _count: { select: { savedBy: true, gallery: true } },
+    },
+  });
+
+  const now = new Date();
+
+  const eventItems = events.map((event) => {
+    const isOwner = event.ownerDj.id === djProfile.id;
+    const participant = event.participants.find(
+      (p) => p.djProfile.id === djProfile.id,
+    );
+    const role = isOwner ? "Owner" : (participant?.role ?? "Performer");
+
+    return {
+      id: event.id,
+      slug: event.slug,
+      title: event.title,
+      eventType: event.eventType,
+      category: event.category,
+      status: event.status,
+      startDate: event.startDate,
+      endDate: event.endDate,
+      venue: event.venue,
+      posterUrl: event.posterUrl,
+      featured: event.featured,
+      viewCount: event.viewCount,
+      location: [event.city?.name, event.country?.name]
+        .filter(Boolean)
+        .join(", "),
+      ownerStageName: event.ownerDj.stageName,
+      ownerSlug: event.ownerDj.slug,
+      role,
+      savedCount: event._count.savedBy,
+      galleryCount: event._count.gallery,
+      isOwner,
+    };
+  });
+
+  const upcoming = eventItems.filter(
+    (e) =>
+      e.status === "PUBLISHED" &&
+      new Date(e.startDate).getTime() >= now.getTime(),
+  );
+  const past = eventItems.filter(
+    (e) =>
+      e.status === "COMPLETED" ||
+      e.status === "CANCELLED" ||
+      e.status === "ARCHIVED" ||
+      (e.status === "PUBLISHED" &&
+        new Date(e.startDate).getTime() < now.getTime()),
+  );
+  const drafts = eventItems.filter((e) => e.status === "DRAFT");
+
+  const emptyState = eventItems.length === 0;
+
   return (
-    <Card className="border-white/10 bg-white/5">
-      <CardContent className="py-12 text-center">
-        <h2 className="text-lg font-semibold text-white">Events</h2>
-        <p className="text-muted-foreground mt-2 text-sm">
-          Coming soon in Phase 2
-        </p>
-      </CardContent>
-    </Card>
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold text-white">My Events</h1>
+          <p className="text-sm text-gray-400">
+            Manage your own events and performances you are listed on.
+          </p>
+        </div>
+        <Button asChild className="mt-2 sm:mt-0">
+          <Link href="/dj/events/new">
+            <Plus className="mr-1 h-4 w-4" />
+            Create Event
+          </Link>
+        </Button>
+      </div>
+
+      {emptyState ? (
+        <div className="rounded-2xl border border-dashed border-white/10 bg-white/5 py-24 text-center">
+          <h2 className="text-lg font-semibold text-white">No events yet</h2>
+          <p className="mt-2 text-sm text-gray-500">
+            Create your first event or get added as a performer by another DJ.
+          </p>
+          <Button className="mt-6" asChild>
+            <Link href="/dj/events/new">Create Event</Link>
+          </Button>
+        </div>
+      ) : (
+        <DjEventsTabs events={eventItems} djSlug={djProfile.slug} />
+      )}
+    </div>
   );
 }

--- a/src/app/dj/loading.tsx
+++ b/src/app/dj/loading.tsx
@@ -1,0 +1,48 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DjLoading() {
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Page header skeleton */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-7 w-48 rounded" />
+          <Skeleton className="h-4 w-72 rounded" />
+        </div>
+        <Skeleton className="mt-2 h-9 w-32 rounded sm:mt-0" />
+      </div>
+
+      {/* Tabs skeleton */}
+      <div className="flex gap-1">
+        <Skeleton className="h-8 w-28 rounded-md" />
+        <Skeleton className="h-8 w-24 rounded-md" />
+        <Skeleton className="h-8 w-20 rounded-md" />
+      </div>
+
+      {/* Content skeleton */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="overflow-hidden rounded-xl border border-white/10 bg-white/5"
+          >
+            <Skeleton className="h-40 w-full rounded-none" />
+            <div className="flex flex-col gap-3 p-4">
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-5 w-20 rounded" />
+                <Skeleton className="h-4 w-16 rounded" />
+              </div>
+              <Skeleton className="h-4 w-3/4 rounded" />
+              <Skeleton className="h-4 w-1/2 rounded" />
+              <div className="mt-2 flex gap-3 border-t border-white/5 pt-3">
+                <Skeleton className="h-3.5 w-16 rounded" />
+                <Skeleton className="h-3.5 w-16 rounded" />
+                <Skeleton className="h-3.5 w-16 rounded" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dj/overview/loading.tsx
+++ b/src/app/dj/overview/loading.tsx
@@ -1,0 +1,111 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DjOverviewLoading() {
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-6 w-28 rounded" />
+        <Skeleton className="h-8 w-36 rounded" />
+      </div>
+
+      {/* Stats row */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Card size="sm" key={i}>
+            <CardHeader>
+              <CardTitle className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
+                <Skeleton className="h-3 w-24 rounded" />
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-20 rounded" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Profile completeness */}
+      <Card className="border-amber-500/20 bg-amber-500/5">
+        <CardContent className="pt-5">
+          <div className="mb-3 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-4 w-4 rounded-full" />
+              <Skeleton className="h-4 w-64 rounded" />
+            </div>
+            <Skeleton className="h-5 w-12 rounded" />
+          </div>
+          <Skeleton className="mb-4 h-1.5 w-full rounded" />
+          <div className="mb-4 flex flex-col gap-1.5">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <Skeleton className="h-1.5 w-1.5 rounded-full" />
+                <Skeleton className="h-4 w-48 rounded" />
+              </div>
+            ))}
+          </div>
+          <Skeleton className="h-8 w-32 rounded" />
+        </CardContent>
+      </Card>
+
+      <Separator />
+
+      {/* Media performance */}
+      <section>
+        <Skeleton className="mb-4 h-4 w-36 rounded" />
+        <div className="grid grid-cols-2 gap-4">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <Card size="sm" key={i}>
+              <CardHeader>
+                <CardTitle className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
+                  <Skeleton className="h-3 w-24 rounded" />
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-8 w-20 rounded" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <Separator />
+
+      {/* Quick actions */}
+      <Skeleton className="h-4 w-28 rounded" />
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Card key={i}>
+            <CardContent className="flex items-center gap-4 py-5">
+              <Skeleton className="h-10 w-10 rounded-lg" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-24 rounded" />
+                <Skeleton className="h-3.5 w-48 rounded" />
+              </div>
+              <Skeleton className="h-8 w-12 rounded" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Separator />
+
+      {/* Tips */}
+      <Card className="border-white/8 bg-white/3">
+        <CardContent className="pt-5">
+          <Skeleton className="mb-3 h-4 w-36 rounded" />
+          <div className="flex flex-col gap-2">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="flex items-start gap-2">
+                <Skeleton className="mt-0.5 h-4 w-4 shrink-0 rounded-full" />
+                <Skeleton className="h-3.5 w-full rounded" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/events/[slug]/edit/page.tsx
+++ b/src/app/events/[slug]/edit/page.tsx
@@ -1,0 +1,89 @@
+import { redirect, notFound } from "next/navigation";
+import { Metadata } from "next";
+import { createClient } from "@/lib/supabase/server";
+import prisma from "@/lib/client";
+import { getCountries } from "@/lib/actions/locations";
+import { getCitiesForCountry } from "@/lib/actions/locations";
+import { EventForm } from "@/components/events/EventForm";
+import type { EventFormData } from "@/components/events/EventForm";
+
+export const metadata: Metadata = { title: "Edit Event — DJcovery" };
+
+export default async function EditEventPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/sign-in");
+
+  const djProfile = await prisma.djProfile.findUnique({
+    where: { userId: user.id },
+    select: { id: true },
+  });
+  if (!djProfile) redirect("/become-dj");
+
+  const event = await prisma.event.findUnique({
+    where: { slug, deletedAt: null },
+    include: {
+      city: { select: { id: true, name: true } },
+      country: { select: { id: true, name: true } },
+      gallery: { orderBy: { sortOrder: "asc" } },
+    },
+  });
+
+  if (!event) notFound();
+  if (event.ownerDjId !== djProfile.id) {
+    redirect("/dj/events");
+  }
+
+  const countries = await getCountries();
+  const initialCities = event.countryId
+    ? await getCitiesForCountry(event.countryId)
+    : [];
+
+  const initialData: Partial<EventFormData> = {
+    title: event.title,
+    eventType: event.eventType,
+    category: event.category as EventFormData["category"],
+    startDate: event.startDate.toISOString().split("T")[0],
+    endDate: event.endDate?.toISOString().split("T")[0] ?? "",
+    startTime: event.startTime ?? "",
+    endTime: event.endTime ?? "",
+    timezone: event.timezone ?? "",
+    countryId: event.countryId?.toString() ?? "",
+    cityId: event.cityId?.toString() ?? "",
+    venue: event.venue ?? "",
+    description: event.description ?? "",
+    ticketUrl: event.ticketUrl ?? "",
+    genres: event.genres,
+    recap: event.recap ?? "",
+    audioLink: event.audioLink ?? "",
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold text-white">Edit Event</h1>
+        <p className="text-sm text-gray-400">
+          Update your event details, poster, and gallery.
+        </p>
+      </div>
+      <EventForm
+        mode="edit"
+        eventId={event.id}
+        eventStatus={event.status}
+        initialData={initialData}
+        countries={countries}
+        initialCities={initialCities.map((c) => ({ id: c.id, name: c.name }))}
+        posterUrl={event.posterUrl}
+        galleryImages={event.gallery.map((g) => ({ id: g.id, url: g.url }))}
+      />
+    </div>
+  );
+}

--- a/src/components/dj/DjEventsTabs.tsx
+++ b/src/components/dj/DjEventsTabs.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import {
+  CalendarDays,
+  MapPin,
+  Eye,
+  Heart,
+  ImageIcon,
+  Star,
+  Lock,
+  ArrowRight,
+  Pencil,
+} from "lucide-react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+export type DjEventItem = {
+  id: number;
+  slug: string;
+  title: string;
+  eventType: string;
+  category: string;
+  status: string;
+  startDate: Date;
+  endDate: Date | null;
+  venue: string | null;
+  posterUrl: string | null;
+  featured: boolean;
+  viewCount: number;
+  location: string;
+  ownerStageName: string;
+  ownerSlug: string;
+  role: string;
+  savedCount: number;
+  galleryCount: number;
+  isOwner: boolean;
+};
+
+type Props = {
+  events: DjEventItem[];
+  djSlug: string;
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  CLUB_NIGHT: "Club Night",
+  FESTIVAL: "Festival",
+  WEDDING: "Wedding",
+  BIRTHDAY: "Birthday",
+  CORPORATE: "Corporate",
+  BEACH_PARTY: "Beach Party",
+  LOUNGE: "Lounge",
+  RESTAURANT_SET: "Restaurant Set",
+  PRIVATE_PARTY: "Private Party",
+  OPEN_AIR: "Open Air",
+  LUXURY_EVENT: "Luxury Event",
+  OTHER: "Other",
+};
+
+const STATUS_THEME: Record<string, { label: string; className: string }> = {
+  DRAFT: { label: "Draft", className: "bg-gray-500/15 text-gray-300" },
+  PUBLISHED: {
+    label: "Published",
+    className: "bg-emerald-500/15 text-emerald-300",
+  },
+  COMPLETED: { label: "Completed", className: "bg-blue-500/15 text-blue-300" },
+  CANCELLED: { label: "Cancelled", className: "bg-red-500/15 text-red-300" },
+  ARCHIVED: { label: "Archived", className: "bg-zinc-500/15 text-zinc-300" },
+};
+
+export default function DjEventsTabs({ events, djSlug }: Props) {
+  const now = new Date();
+
+  const upcoming = events.filter(
+    (e) =>
+      e.status === "PUBLISHED" &&
+      new Date(e.startDate).getTime() >= now.getTime(),
+  );
+  const past = events.filter(
+    (e) =>
+      e.status === "COMPLETED" ||
+      e.status === "CANCELLED" ||
+      e.status === "ARCHIVED" ||
+      (e.status === "PUBLISHED" &&
+        new Date(e.startDate).getTime() < now.getTime()),
+  );
+  const drafts = events.filter((e) => e.status === "DRAFT");
+
+  const tabs = [
+    { value: "upcoming", label: "Upcoming", count: upcoming.length },
+    { value: "past", label: "Past", count: past.length },
+    { value: "drafts", label: "Drafts", count: drafts.length },
+  ];
+
+  const [activeTab, setActiveTab] = useState(
+    upcoming.length > 0 ? "upcoming" : past.length > 0 ? "past" : "drafts",
+  );
+
+  return (
+    <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+      <TabsList className="mb-6 w-fit bg-white/5">
+        {tabs.map((tab) => (
+          <TabsTrigger
+            key={tab.value}
+            value={tab.value}
+            className="data-active:bg-h_redDark flex-initial gap-1 px-4 data-active:text-white"
+          >
+            {tab.label}
+            {tab.count > 0 && (
+              <span className="text-xs opacity-70">({tab.count})</span>
+            )}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+
+      <TabsContent value="upcoming" className="mt-0">
+        {upcoming.length > 0 ? (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {upcoming.map((event) => (
+              <EventCard key={event.id} event={event} djSlug={djSlug} />
+            ))}
+          </div>
+        ) : (
+          <EmptyState message="No upcoming events." />
+        )}
+      </TabsContent>
+
+      <TabsContent value="past" className="mt-0">
+        {past.length > 0 ? (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {past.map((event) => (
+              <EventCard key={event.id} event={event} djSlug={djSlug} />
+            ))}
+          </div>
+        ) : (
+          <EmptyState message="No past events." />
+        )}
+      </TabsContent>
+
+      <TabsContent value="drafts" className="mt-0">
+        {drafts.length > 0 ? (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {drafts.map((event) => (
+              <EventCard key={event.id} event={event} djSlug={djSlug} />
+            ))}
+          </div>
+        ) : (
+          <EmptyState message="No draft events." />
+        )}
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+function EventCard({ event, djSlug }: { event: DjEventItem; djSlug: string }) {
+  const router = useRouter();
+  const categoryLabel = CATEGORY_LABELS[event.category] ?? event.category;
+  const statusTheme = STATUS_THEME[event.status] ?? {
+    label: event.status,
+    className: "bg-gray-500/15 text-gray-300",
+  };
+  const isPrivate = event.eventType === "PRIVATE";
+  const isOwnEvent = event.ownerSlug === djSlug;
+
+  const dateDisplay = new Date(event.startDate).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+
+  return (
+    <Link
+      href={`/events/${event.slug}`}
+      className="group flex flex-col overflow-hidden rounded-xl border border-white/10 bg-white/5 transition-colors hover:border-white/20 hover:bg-white/3"
+    >
+      <div className="relative h-40 overflow-hidden">
+        {event.posterUrl ? (
+          <Image
+            src={event.posterUrl}
+            alt={event.title}
+            fill
+            className="object-cover transition-transform duration-300 group-hover:scale-105"
+          />
+        ) : (
+          <div className="from-h_redDark/30 flex h-full w-full items-center justify-center bg-linear-to-br to-black">
+            <ImageIcon className="h-10 w-10 text-white/20" />
+          </div>
+        )}
+        <div className="absolute inset-0 bg-linear-to-t from-black/80 via-black/20 to-transparent" />
+
+        <div className="absolute top-3 left-3 flex flex-wrap gap-1.5">
+          {isPrivate && (
+            <span className="flex items-center gap-1 rounded-full bg-black/60 px-2 py-0.5 text-[11px] text-zinc-400 backdrop-blur-sm">
+              <Lock className="h-2.5 w-2.5" />
+              Private
+            </span>
+          )}
+          <span className="rounded-full bg-black/60 px-2 py-0.5 text-[11px] text-zinc-300 backdrop-blur-sm">
+            {categoryLabel}
+          </span>
+          {event.featured && (
+            <span className="flex items-center gap-1 rounded-full bg-amber-500/20 px-2 py-0.5 text-[11px] text-amber-300 backdrop-blur-sm">
+              <Star className="h-2.5 w-2.5" />
+              Featured
+            </span>
+          )}
+        </div>
+
+        {event.isOwner && (
+          <div className="absolute top-3 right-3">
+            <Button
+              size="sm"
+              variant="secondary"
+              className="h-7 gap-1 bg-black/60 text-xs text-white backdrop-blur-sm hover:bg-black/80"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                router.push(`/events/${event.slug}/edit`);
+              }}
+            >
+              <Pencil className="h-3 w-3" />
+              Edit
+            </Button>
+          </div>
+        )}
+
+        <div className="absolute right-3 bottom-3 left-3">
+          <h3 className="text-lg leading-tight font-bold text-white drop-shadow-md">
+            {event.title}
+          </h3>
+        </div>
+      </div>
+
+      <div className="flex flex-1 flex-col gap-2 p-4">
+        <div className="flex items-center justify-between">
+          <Badge
+            variant="outline"
+            className={`${statusTheme.className} border-0`}
+          >
+            {statusTheme.label}
+          </Badge>
+          <span className="text-xs text-gray-500">{event.role}</span>
+        </div>
+
+        <div className="flex items-center gap-2 text-sm text-gray-300">
+          <CalendarDays className="h-3.5 w-3.5 text-gray-500" />
+          <span>{dateDisplay}</span>
+          {event.venue && (
+            <>
+              <span className="text-gray-600">·</span>
+              <span className="text-gray-500">{event.venue}</span>
+            </>
+          )}
+        </div>
+
+        {event.location && (
+          <div className="flex items-center gap-2 text-sm text-gray-400">
+            <MapPin className="h-3.5 w-3.5 text-gray-500" />
+            <span className="truncate">{event.location}</span>
+          </div>
+        )}
+
+        <div className="mt-auto flex items-center justify-between border-t border-white/5 pt-3 text-xs text-gray-500">
+          <div className="flex items-center gap-3">
+            <span className="flex items-center gap-1">
+              <Eye className="h-3.5 w-3.5" />
+              {event.viewCount.toLocaleString()}
+            </span>
+            <span className="flex items-center gap-1">
+              <Heart className="h-3.5 w-3.5" />
+              {event.savedCount}
+            </span>
+            <span className="flex items-center gap-1">
+              <ImageIcon className="h-3.5 w-3.5" />
+              {event.galleryCount}
+            </span>
+          </div>
+          <span className="text-h_red group-hover:text-h_redLight flex items-center gap-1">
+            Details
+            <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="rounded-2xl border border-dashed border-white/10 bg-white/5 py-16 text-center">
+      <p className="text-sm text-gray-500">{message}</p>
+    </div>
+  );
+}

--- a/src/components/events/EventForm.tsx
+++ b/src/components/events/EventForm.tsx
@@ -52,7 +52,7 @@ import { getTimezoneByCountryCode } from "@/lib/timezones";
 export type CountryOption = { id: number; name: string; code?: string };
 export type CityOption = { id: number; name: string };
 
-type EventFormData = {
+export type EventFormData = {
   title: string;
   eventType: "PUBLIC" | "PRIVATE";
   category: EventCategory | "";


### PR DESCRIPTION
… and empty state

- Add events page with tabbed interface for upcoming, past, and draft events
- Fetch and display DJ's owned events and performances with role, location, and stats
- Add EventRow component with event type, date, venue, and status badges
- Add empty state with create event CTA when no events exist
- Add create event button in page header linking to /dj/events/new
- Export EventFormData type for reuse in event creation