### PR TITLE
refactor(proxy): remove root path from always public paths list

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,7 +12,6 @@ const isProduction =
 // coming-soon placeholder. Auth paths and /admin stay reachable so the team can
 // still sign in; everything else redirects to /coming-soon.
 const ALWAYS_PUBLIC_PATHS = [
-  "/",
   "/coming-soon",
   "/sign-in",
   "/sign-up",


### PR DESCRIPTION
- Remove "/" from ALWAYS_PUBLIC_PATHS array
- Root path will now follow standard redirect behavior instead of being always public