### PR TITLE
fix(dj-settings): add full width styling to country and city select t…

### DIFF
--- a/src/components/dj/DjSettingsTabs.tsx
+++ b/src/components/dj/DjSettingsTabs.tsx
@@ -358,7 +358,7 @@ function ProfileTab({
               value={countryId ? String(countryId) : ""}
               onValueChange={handleCountryChange}
             >
-              <SelectTrigger>
+              <SelectTrigger className="w-full">
                 <SelectValue placeholder="Select country..." />
               </SelectTrigger>
               <SelectContent>
@@ -383,7 +383,7 @@ function ProfileTab({
                 onValueChange={(v) => setCityId(v ? Number(v) : null)}
                 disabled={!countryId}
               >
-                <SelectTrigger>
+                <SelectTrigger className="w-full">
                   <SelectValue placeholder="Select city..." />
                 </SelectTrigger>
                 <SelectContent>


### PR DESCRIPTION
…riggers

- Add w-full className to country SelectTrigger
- Add w-full className to city SelectTrigger
- Ensure consistent width for location selection dropdowns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the Country and City dropdown fields in Location settings to use the available width for a more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->