### PR TITLE
refactor: improve DjCard layout and increase directory pagination size

### DIFF
--- a/src/app/directory/loading.tsx
+++ b/src/app/directory/loading.tsx
@@ -35,7 +35,7 @@ export default function DirectoryLoading() {
 
           {/* DJ Grid skeleton */}
           <div className="w-full">
-            <DjGridSkeleton count={9} />
+            <DjGridSkeleton count={12} />
           </div>
         </div>
       </div>

--- a/src/components/directory/DjCard.tsx
+++ b/src/components/directory/DjCard.tsx
@@ -97,21 +97,13 @@ const DjCard = ({
               showScore={false}
               className="px-2 py-0.5 text-xs"
             />
-            <span className="text-xs text-gray-500">
-              {gigReviews.length + eventReviews.length + ratings.length} reviews
-            </span>
-            {_count !== undefined && (
-              <span className="text-xs text-gray-500">
-                • {formatNumber(_count.followers)} followers
-              </span>
-            )}
           </div>
         </div>
       </Link>
 
       {genreList.length > 0 && (
         <div className="mt-1 flex flex-wrap gap-1">
-          {genreList.slice(0, 3).map((genre) => (
+          {genreList.slice(0, 2).map((genre) => (
             <span
               key={genre}
               className="bg-h_redDark/60 rounded-full px-2 py-0.5 text-xs text-red-200"
@@ -119,15 +111,28 @@ const DjCard = ({
               {genre}
             </span>
           ))}
+          {genreList.length > 2 && (
+            <span className="bg-h_redDark/60 rounded-full px-2 py-0.5 text-xs text-red-200">
+              +{genreList.length - 2}
+            </span>
+          )}
         </div>
       )}
 
-      <Link
-        href={profileHref}
-        className="bg-h_red hover:bg-h_redDark focus-visible:ring-h_red mt-auto w-full cursor-pointer rounded-md px-3 py-1.5 text-center text-xs text-white transition-all outline-none focus-visible:ring-2 focus-visible:ring-offset-1 active:scale-95"
-      >
-        View Profile
-      </Link>
+      <div className="my-2 border-t border-gray-700/50" />
+
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs text-gray-400">
+          {gigReviews.length + eventReviews.length + ratings.length === 0
+            ? "New"
+            : `${gigReviews.length + eventReviews.length + ratings.length} reviews`}
+        </span>
+        {_count !== undefined && (
+          <span className="text-xs text-gray-400">
+            {formatNumber(_count.followers)} followers
+          </span>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/directory/DjCard.tsx
+++ b/src/components/directory/DjCard.tsx
@@ -123,13 +123,17 @@ const DjCard = ({
 
       <div className="flex items-center justify-between gap-2">
         <span className="text-xs text-gray-400">
-          {gigReviews.length + eventReviews.length + ratings.length === 0
-            ? "New"
-            : `${gigReviews.length + eventReviews.length + ratings.length} reviews`}
+          {(() => {
+            const total =
+              gigReviews.length + eventReviews.length + ratings.length;
+            if (total === 0) return "New";
+            return `${total} review${total === 1 ? "" : "s"}`;
+          })()}
         </span>
         {_count !== undefined && (
           <span className="text-xs text-gray-400">
-            {formatNumber(_count.followers)} followers
+            {formatNumber(_count.followers)} follower
+            {_count.followers === 1 ? "" : "s"}
           </span>
         )}
       </div>

--- a/src/components/directory/DjGrid.tsx
+++ b/src/components/directory/DjGrid.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { DjUser } from "@/lib/data";
 import DjCard from "./DjCard";
 
-const PAGE_SIZE = 9;
+const PAGE_SIZE = 12;
 
 type DjGridProps = {
   djs: DjUser[];

--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -70,6 +70,7 @@ export function EventCard({
               fill
               sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
               className="object-cover"
+              priority
             />
           ) : (
             <div className="bg-h_redDark/20 absolute inset-0" />

--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -51,9 +51,11 @@ function formatDate(date: Date): string {
 export function EventCard({
   event,
   isSaved = false,
+  priority = false,
 }: {
   event: EventCardItem;
   isSaved?: boolean;
+  priority?: boolean;
 }) {
   const isPrivate = event.eventType === "PRIVATE";
   const categoryLabel = CATEGORY_LABELS[event.category] ?? event.category;
@@ -70,7 +72,7 @@ export function EventCard({
               fill
               sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
               className="object-cover"
-              priority
+              priority={priority}
             />
           ) : (
             <div className="bg-h_redDark/20 absolute inset-0" />


### PR DESCRIPTION
- Increase DJ grid page size from 9 to 12 items
- Relocate review and follower counts below genre tags with divider
- Limit genre display to 2 tags with overflow counter
- Update text styling to gray-400 for metadata
- Remove "View Profile" button (card itself is clickable)
- Show "New" label for DJs without reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DJ directory cards now show up to two genre pills plus a compact “+N” for additional genres.
  * Reviews now display **“New”** when there are no gig/event reviews or ratings; the reviews/followers area formatting was updated for a cleaner layout.
* **Improvements**
  * The directory now shows **12 DJs** initially and loads **12 more** per “Load more.”
  * Loading placeholders were updated to match the expanded grid layout.
  * Event posters now render with higher loading priority when a poster URL is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->