### PR TITLE
fix(email): make Resend client lazy/null-safe for e2e builds

### DIFF
--- a/src/lib/email/client.ts
+++ b/src/lib/email/client.ts
@@ -1,5 +1,7 @@
 import { Resend } from "resend";
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+const resend = process.env.RESEND_API_KEY
+  ? new Resend(process.env.RESEND_API_KEY)
+  : null;
 
 export default resend;

--- a/src/lib/email/sendEmail.ts
+++ b/src/lib/email/sendEmail.ts
@@ -34,7 +34,7 @@ export async function sendEmail({
   from: fromOverride,
 }: SendEmailParams): Promise<void> {
   const prismaEmailType = emailType as EmailType;
-  if (!process.env.RESEND_API_KEY) {
+  if (!resend || !process.env.RESEND_API_KEY) {
     console.log(
       `[sendEmail] RESEND_API_KEY not set — skipping: ${emailType} → ${maskEmail(to)}`,
     );
@@ -55,6 +55,7 @@ export async function sendEmail({
         emailType,
       });
     }
+    return;
   }
 
   const from =


### PR DESCRIPTION
- Do not instantiate Resend when RESEND_API_KEY is missing
- Return early from sendEmail when client is not configured
- Fixes npm run e2e failing on missing API key