### PR TITLE
feat(analytics): add response rate, booking rate, and top cities trac…

### DIFF
--- a/src/app/api/track-profile-view/route.ts
+++ b/src/app/api/track-profile-view/route.ts
@@ -7,7 +7,10 @@ export async function POST(req: NextRequest) {
     const { djProfileId } = await req.json();
 
     if (!djProfileId || typeof djProfileId !== "number") {
-      return NextResponse.json({ error: "Invalid djProfileId" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Invalid djProfileId" },
+        { status: 400 },
+      );
     }
 
     const supabase = await createClient();
@@ -21,8 +24,13 @@ export async function POST(req: NextRequest) {
         where: { id: djProfileId },
         select: { userId: true, status: true, hidden: true },
       });
-      if (!profile) return NextResponse.json({ error: "Profile not found" }, { status: 404 });
-      if (profile.userId === user.id) return NextResponse.json({ success: true });
+      if (!profile)
+        return NextResponse.json(
+          { error: "Profile not found" },
+          { status: 404 },
+        );
+      if (profile.userId === user.id)
+        return NextResponse.json({ success: true });
       if (profile.status !== "APPROVED" || profile.hidden) {
         return NextResponse.json({ success: true });
       }
@@ -32,7 +40,11 @@ export async function POST(req: NextRequest) {
         where: { id: djProfileId },
         select: { status: true, hidden: true },
       });
-      if (!profile) return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+      if (!profile)
+        return NextResponse.json(
+          { error: "Profile not found" },
+          { status: 404 },
+        );
       if (profile.status !== "APPROVED" || profile.hidden) {
         return NextResponse.json({ success: true });
       }
@@ -44,11 +56,28 @@ export async function POST(req: NextRequest) {
     if (hasViewed) return NextResponse.json({ success: true });
 
     // Create profile view record
+    // Capture viewer city/country for Top Cities analytics
+    let viewerCity: string | null = null;
+    let viewerCountry: string | null = null;
+    if (user) {
+      const viewerProfile = await prisma.user.findUnique({
+        where: { id: user.id },
+        select: {
+          city: { select: { name: true } },
+          country: { select: { name: true } },
+        },
+      });
+      viewerCity = viewerProfile?.city?.name ?? null;
+      viewerCountry = viewerProfile?.country?.name ?? null;
+    }
+
     await prisma.profileView.create({
       data: {
         djProfileId,
         viewerId: user?.id ?? null,
         source: null,
+        city: viewerCity,
+        country: viewerCountry,
       },
     });
 

--- a/src/app/dj/analytics/page.tsx
+++ b/src/app/dj/analytics/page.tsx
@@ -12,7 +12,11 @@ import {
   getDjBookingsByStatus,
   getDjTopMedia,
   getDjProfileViewSources,
+  getDjResponseRate,
+  getDjBookingRate,
+  getDjTopCities,
 } from "@/lib/queries/dj-stats";
+import { normalisePlan, hasFeature } from "@/lib/plan-features";
 
 export const metadata = { title: "Analytics — DJcovery" };
 
@@ -25,12 +29,14 @@ export default async function DjAnalyticsPage() {
 
   const djProfile = await prisma.djProfile.findUnique({
     where: { userId: user.id },
-    select: { id: true, slug: true },
+    select: { id: true, slug: true, plan: true },
   });
 
   if (!djProfile) redirect("/become-dj");
 
-  const days = 30;
+  const plan = normalisePlan(djProfile.plan);
+  const hasAdvancedAnalytics = hasFeature(plan, "advancedAnalyticsAccess");
+  const days = hasAdvancedAnalytics ? 30 : 7;
   const [
     followers,
     bookings,
@@ -41,6 +47,9 @@ export default async function DjAnalyticsPage() {
     bookingsByStatus,
     topMedia,
     sources,
+    responseRate,
+    bookingRate,
+    topCities,
   ] = await Promise.all([
     getDjFollowerCount(djProfile.id),
     getDjBookingCount(djProfile.id),
@@ -51,23 +60,30 @@ export default async function DjAnalyticsPage() {
     getDjBookingsByStatus(djProfile.id),
     getDjTopMedia(djProfile.id, 5),
     getDjProfileViewSources(djProfile.id),
+    getDjResponseRate(djProfile.id),
+    getDjBookingRate(djProfile.id),
+    getDjTopCities(djProfile.id, 5),
   ]);
 
   return (
     <DjAnalyticsDashboard
       slug={djProfile.slug}
+      plan={plan}
       totals={{
         followers,
         bookings,
         profileViews,
         mediaPlays: mediaStats.plays,
         mediaViews: mediaStats.views,
+        responseRate,
+        bookingRate,
       }}
       viewsOverTime={viewsOverTime}
       followersOverTime={followersOverTime}
       bookingsByStatus={bookingsByStatus}
       topMedia={topMedia}
       sources={sources}
+      topCities={topCities}
     />
   );
 }

--- a/src/app/djs/[slug]/page.tsx
+++ b/src/app/djs/[slug]/page.tsx
@@ -11,6 +11,11 @@ import type { DjDemoData, ViewMode } from "@/types/dj-demo";
 import type { BookingFormOptions, BookingViewerContext } from "@/types/booking";
 import { getCitiesForCountry, getVenuesForCity } from "@/lib/actions/locations";
 import { fetchYouTubeOEmbed } from "@/lib/actions/media";
+import {
+  getDjResponseRate,
+  getDjBookingRate,
+  getDjTopCities,
+} from "@/lib/queries/dj-stats";
 import JsonLd from "@/components/seo/JsonLd";
 
 export default async function DjProfilePage({
@@ -187,19 +192,23 @@ export default async function DjProfilePage({
 
   // Accurate aggregates: avg rating over ALL ratings (not just the fetched 20),
   // and event count limited to publicly visible events (matches the list shown).
-  const [ratingAgg, publicEventsCount] = await Promise.all([
-    prisma.djRating.aggregate({
-      where: { djProfileId: dj.id },
-      _avg: { rating: true },
-    }),
-    prisma.event.count({
-      where: {
-        ownerDjId: dj.id,
-        status: { in: ["PUBLISHED", "COMPLETED"] },
-        deletedAt: null,
-      },
-    }),
-  ]);
+  const [ratingAgg, publicEventsCount, responseRate, bookingRate, topCities] =
+    await Promise.all([
+      prisma.djRating.aggregate({
+        where: { djProfileId: dj.id },
+        _avg: { rating: true },
+      }),
+      prisma.event.count({
+        where: {
+          ownerDjId: dj.id,
+          status: { in: ["PUBLISHED", "COMPLETED"] },
+          deletedAt: null,
+        },
+      }),
+      getDjResponseRate(dj.id),
+      getDjBookingRate(dj.id),
+      getDjTopCities(dj.id, 5),
+    ]);
   const avgRating = ratingAgg._avg.rating ?? 0;
 
   // Fetch YouTube oEmbed thumbnail server-side for Featured Performance
@@ -341,8 +350,8 @@ export default async function DjProfilePage({
       rating: avgRating,
       reviews: dj._count.ratings,
       events: publicEventsCount,
-      responseRate: 0,
-      bookingRate: 0,
+      responseRate,
+      bookingRate,
       monthlyViews: dj.monthlyViews ?? 0,
     },
     spotlight: {
@@ -375,8 +384,12 @@ export default async function DjProfilePage({
       profileViews: { value: dj.monthlyViews ?? 0, growth: 0 },
       bookingRequests: { value: 0, growth: 0 },
       newFollowers: { value: 0, growth: 0 },
-      bookingRate: 0,
-      topCities: [],
+      bookingRate,
+      topCities: topCities.map((c) => ({
+        city: c.city,
+        country: c.country,
+        percentage: 0,
+      })),
       audienceAge: [],
       trafficSources: [],
     },

--- a/src/app/djs/[slug]/page.tsx
+++ b/src/app/djs/[slug]/page.tsx
@@ -16,6 +16,7 @@ import {
   getDjBookingRate,
   getDjTopCities,
 } from "@/lib/queries/dj-stats";
+import { getProfileStats } from "@/lib/actions/dj-analytics";
 import JsonLd from "@/components/seo/JsonLd";
 
 export default async function DjProfilePage({
@@ -192,23 +193,31 @@ export default async function DjProfilePage({
 
   // Accurate aggregates: avg rating over ALL ratings (not just the fetched 20),
   // and event count limited to publicly visible events (matches the list shown).
-  const [ratingAgg, publicEventsCount, responseRate, bookingRate, topCities] =
-    await Promise.all([
-      prisma.djRating.aggregate({
-        where: { djProfileId: dj.id },
-        _avg: { rating: true },
-      }),
-      prisma.event.count({
-        where: {
-          ownerDjId: dj.id,
-          status: { in: ["PUBLISHED", "COMPLETED"] },
-          deletedAt: null,
-        },
-      }),
-      getDjResponseRate(dj.id),
-      getDjBookingRate(dj.id),
-      getDjTopCities(dj.id, 5),
-    ]);
+  const [
+    ratingAgg,
+    publicEventsCount,
+    responseRate,
+    bookingRate,
+    topCities,
+    ownerProfileStats,
+  ] = await Promise.all([
+    prisma.djRating.aggregate({
+      where: { djProfileId: dj.id },
+      _avg: { rating: true },
+    }),
+    prisma.event.count({
+      where: {
+        ownerDjId: dj.id,
+        status: { in: ["PUBLISHED", "COMPLETED"] },
+        deletedAt: null,
+      },
+    }),
+    getDjResponseRate(dj.id),
+    getDjBookingRate(dj.id),
+    getDjTopCities(dj.id, 5),
+    // Only returns data if the current viewer is the profile owner on a PREMIUM plan
+    getProfileStats(dj.id),
+  ]);
   const avgRating = ratingAgg._avg.rating ?? 0;
 
   // Fetch YouTube oEmbed thumbnail server-side for Featured Performance
@@ -381,9 +390,18 @@ export default async function DjProfilePage({
       })(),
     },
     analytics: {
-      profileViews: { value: dj.monthlyViews ?? 0, growth: 0 },
-      bookingRequests: { value: 0, growth: 0 },
-      newFollowers: { value: 0, growth: 0 },
+      profileViews: ownerProfileStats?.profileViews ?? {
+        value: dj.monthlyViews ?? 0,
+        growth: 0,
+      },
+      bookingRequests: ownerProfileStats?.bookingRequests ?? {
+        value: 0,
+        growth: 0,
+      },
+      newFollowers: ownerProfileStats?.newFollowers ?? {
+        value: 0,
+        growth: 0,
+      },
       bookingRate,
       topCities: topCities.map((c) => ({
         city: c.city,

--- a/src/components/dj-profile/DjProfileFree.tsx
+++ b/src/components/dj-profile/DjProfileFree.tsx
@@ -121,20 +121,47 @@ export default function DjProfileFree({
 } = {}) {
   const djProfileId = djData ? parseInt(djData.id) : NaN;
   const [bioExpanded, setBioExpanded] = useState(false);
+  const isStaging = process.env.NEXT_PUBLIC_APP_ENV === "staging";
+  const isProduction = process.env.NEXT_PUBLIC_APP_ENV === "production";
 
-  const DJ = djData ? mapFreeDjToProps(djData) : FREE_DEFAULT_DJ;
-  const EVENTS = djData ? mapFreeEventsFromData(djData) : FREE_DEFAULT_EVENTS;
-  const REVIEWS = djData ? mapFreeReviewsFromData(djData) : [];
-  const MEDIA = djData ? mapFreeMediaFromData(djData) : FREE_DEFAULT_MEDIA;
+  // In staging: use real data if available, supplement with demo data
+  // In production: only use real data
+  const DJ = djData
+    ? mapFreeDjToProps(djData)
+    : isStaging
+      ? FREE_DEFAULT_DJ
+      : null;
+  const EVENTS = djData
+    ? mapFreeEventsFromData(djData)
+    : isStaging
+      ? FREE_DEFAULT_EVENTS
+      : [];
+  const REVIEWS = djData
+    ? mapFreeReviewsFromData(djData)
+    : isStaging
+      ? FREE_DEFAULT_REVIEWS
+      : [];
+  const MEDIA = djData
+    ? mapFreeMediaFromData(djData)
+    : isStaging
+      ? FREE_DEFAULT_MEDIA
+      : [];
   const FEATURED_MIX = djData
     ? mapFreeFeaturedMix(djData)
-    : FREE_DEFAULT_FEATURED_MIX;
+    : isStaging
+      ? FREE_DEFAULT_FEATURED_MIX
+      : null;
   const videoUrl = djData?.spotlight.featuredVideo.videoUrl ?? "";
   const videoThumb =
     djData?.spotlight.featuredVideo.thumbnail ||
     getVideoThumbnailUrl(videoUrl) ||
     "/gallery-2.png";
-  const location = `${DJ.city}, ${DJ.country}`;
+  const location = DJ ? `${DJ.city}, ${DJ.country}` : "";
+
+  // Early return in production if no data available
+  if (!DJ && isProduction) {
+    return null;
+  }
 
   const isOwner = viewMode === "dj-owner";
   const editHref = "/dj/settings";
@@ -485,8 +512,8 @@ export default function DjProfileFree({
                   {(
                     [
                       {
-                        title: "Performance Insights",
-                        desc: "Analytics, profile views & booking stats",
+                        title: "Advanced Analytics",
+                        desc: "30-day trends, charts & demographic insights",
                         icon: ChartLine,
                       },
                       {

--- a/src/components/dj-profile/DjProfileFree.tsx
+++ b/src/components/dj-profile/DjProfileFree.tsx
@@ -158,10 +158,21 @@ export default function DjProfileFree({
     "/gallery-2.png";
   const location = DJ ? `${DJ.city}, ${DJ.country}` : "";
 
+  const featuredMixAudioUrl = FEATURED_MIX?.audioUrl ?? "";
+  // Hooks must run unconditionally before any early return (Rules of Hooks)
+  const autoMixThumb = useAudioThumbnail(featuredMixAudioUrl);
+  const featuredMixThumb =
+    FEATURED_MIX?.thumbnail || autoMixThumb || "/gallery-2.png";
+
   // Early return in production if no data available
   if (!DJ && isProduction) {
     return null;
   }
+
+  // After this point, DJ and FEATURED_MIX are guaranteed to be non-null
+  // (either from real data or demo defaults in staging)
+  const safeDJ = DJ!;
+  const safeFEATURED_MIX = FEATURED_MIX!;
 
   const isOwner = viewMode === "dj-owner";
   const editHref = "/dj/settings";
@@ -170,16 +181,11 @@ export default function DjProfileFree({
     isAuthenticated: false,
   };
 
-  const hasFeaturedMix = FEATURED_MIX.audioUrl !== "";
+  const hasFeaturedMix = safeFEATURED_MIX.audioUrl !== "";
   const hasFeaturedVideo = !!djData?.spotlight.featuredVideo.videoUrl;
   const hasSpotlight = hasFeaturedMix || hasFeaturedVideo;
   const hasMixes = hasFeaturedMix;
   const hasPhotos = MEDIA.length > 0;
-
-  const featuredMixAudioUrl = FEATURED_MIX.audioUrl;
-  const autoMixThumb = useAudioThumbnail(featuredMixAudioUrl);
-  const featuredMixThumb =
-    FEATURED_MIX.thumbnail || autoMixThumb || "/gallery-2.png";
 
   const completion = djData ? calculateProfileCompletion(djData) : null;
 
@@ -214,7 +220,7 @@ export default function DjProfileFree({
             </div>
             {/* ── MOBILE BOOK CTA ── */}
             <BookCTA
-              stageName={`Dj. ${DJ.stageName}`}
+              stageName={`Dj. ${safeDJ.stageName}`}
               djProfileId={djProfileId}
               viewer={bookingContext}
               variant="free"
@@ -224,8 +230,8 @@ export default function DjProfileFree({
 
             <div id="about">
               <ProfileAbout
-                bio={DJ.bio}
-                djTypes={DJ.djTypes}
+                bio={safeDJ.bio}
+                djTypes={safeDJ.djTypes}
                 bioExpanded={bioExpanded}
                 onToggleBio={() => setBioExpanded(!bioExpanded)}
                 experienceYears={djData?.experienceYears}
@@ -249,8 +255,8 @@ export default function DjProfileFree({
                 </SectionHeading>
                 {hasMixes ? (
                   <MediaAudioPlayer
-                    audioUrl={FEATURED_MIX.audioUrl}
-                    title={FEATURED_MIX.title}
+                    audioUrl={safeFEATURED_MIX.audioUrl}
+                    title={safeFEATURED_MIX.title}
                     thumbnailUrl={featuredMixThumb || undefined}
                   >
                     <Card className="bg-h_blackLight/30 cursor-pointer gap-0 border-white/8 p-4 transition-colors hover:border-white/15">
@@ -259,7 +265,7 @@ export default function DjProfileFree({
                           {featuredMixThumb ? (
                             <Image
                               src={featuredMixThumb}
-                              alt={FEATURED_MIX.title}
+                              alt={safeFEATURED_MIX.title}
                               fill
                               className="object-cover"
                             />
@@ -269,11 +275,12 @@ export default function DjProfileFree({
                         </div>
                         <div className="min-w-0 flex-1">
                           <p className="text-sm font-semibold text-white">
-                            {FEATURED_MIX.title}
+                            {safeFEATURED_MIX.title}
                           </p>
                           <p className="mt-0.5 text-xs text-gray-500">
-                            {FEATURED_MIX.platform} · {FEATURED_MIX.duration} ·{" "}
-                            {FEATURED_MIX.plays} plays
+                            {safeFEATURED_MIX.platform} ·{" "}
+                            {safeFEATURED_MIX.duration} ·{" "}
+                            {safeFEATURED_MIX.plays} plays
                           </p>
                           <div className="mt-2 flex items-center gap-2">
                             <div className="h-1 flex-1 overflow-hidden rounded-full bg-white/10">
@@ -321,17 +328,17 @@ export default function DjProfileFree({
                       {/* Featured Mix */}
                       {hasFeaturedMix && (
                         <MediaAudioPlayer
-                          audioUrl={FEATURED_MIX.audioUrl}
-                          title={FEATURED_MIX.title}
+                          audioUrl={safeFEATURED_MIX.audioUrl}
+                          title={safeFEATURED_MIX.title}
                           thumbnailUrl={featuredMixThumb || undefined}
-                          mediaId={FEATURED_MIX.id}
+                          mediaId={safeFEATURED_MIX.id}
                         >
                           <Card className="bg-h_blackLight/30 group hover:border-h_red/30 flex h-full cursor-pointer flex-col gap-0 overflow-hidden border-white/8 transition-all">
                             <div className="from-h_red/20 relative h-40 shrink-0 bg-linear-to-br to-black">
                               {featuredMixThumb ? (
                                 <Image
                                   src={featuredMixThumb}
-                                  alt={FEATURED_MIX.title}
+                                  alt={safeFEATURED_MIX.title}
                                   fill
                                   className="object-cover opacity-50 transition-opacity group-hover:opacity-60"
                                 />
@@ -350,14 +357,14 @@ export default function DjProfileFree({
                             </div>
                             <div className="p-4">
                               <p className="text-sm font-semibold text-white">
-                                {FEATURED_MIX.title}
+                                {safeFEATURED_MIX.title}
                               </p>
                               <p className="mt-1 text-xs text-gray-500">
-                                {FEATURED_MIX.duration} · {FEATURED_MIX.plays}{" "}
-                                plays
+                                {safeFEATURED_MIX.duration} ·{" "}
+                                {safeFEATURED_MIX.plays} plays
                               </p>
                               <div className="mt-2 flex items-center gap-1">
-                                {FEATURED_MIX.genres.map((t) => (
+                                {safeFEATURED_MIX.genres.map((t) => (
                                   <Badge
                                     key={t}
                                     className="h-4 border-white/10 bg-white/5 text-[11px] text-gray-400"
@@ -452,7 +459,7 @@ export default function DjProfileFree({
                 calendarDays={[]}
                 calendarLabel="Calendar"
                 isOwner={isOwner}
-                djName={DJ.stageName}
+                djName={safeDJ.stageName}
                 featuredPerformanceUrl={djData?.featuredPerformanceUrl}
                 featuredPerformanceContext={djData?.featuredPerformanceContext}
                 featuredPerformanceThumbnailUrl={
@@ -470,8 +477,8 @@ export default function DjProfileFree({
                 </SectionHeading>
                 {REVIEWS.length > 0 ? (
                   <ProfileReviews
-                    avgRating={DJ.avgRating}
-                    ratingCount={DJ.ratingCount}
+                    avgRating={safeDJ.avgRating}
+                    ratingCount={safeDJ.ratingCount}
                     reviews={REVIEWS}
                   />
                 ) : (
@@ -569,13 +576,13 @@ export default function DjProfileFree({
               <ProfileEventsSidebar
                 events={EVENTS}
                 isOwner={isOwner}
-                djName={DJ.stageName}
+                djName={safeDJ.stageName}
               />
             </div>
 
             {/* Book CTA — desktop only; mobile version is inline above */}
             <BookCTA
-              stageName={`Dj. ${DJ.stageName}`}
+              stageName={`Dj. ${safeDJ.stageName}`}
               djProfileId={djProfileId}
               viewer={bookingContext}
               variant="free"

--- a/src/components/dj-profile/DjProfileHero.tsx
+++ b/src/components/dj-profile/DjProfileHero.tsx
@@ -18,6 +18,7 @@ import {
   Zap,
   Handshake,
   Eye,
+  ChartLine,
 } from "lucide-react";
 import { SOCIAL_ICONS } from "./dj-profile-shared";
 import { ReputationBadge } from "./ReputationBadge";
@@ -199,17 +200,30 @@ function DjProfileHero({
           {/* Action Buttons */}
           <div className="flex items-center gap-2 sm:pb-2">
             {isOwner && djData?.slug ? (
-              <Button
-                variant="outline"
-                size="sm"
-                className="border-amber-500/50 text-amber-300 hover:bg-amber-500/10"
-                asChild
-              >
-                <Link href={editHref}>
-                  <Pencil className="mr-1.5 h-3.5 w-3.5" />
-                  Edit Profile
-                </Link>
-              </Button>
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-amber-500/50 text-amber-300 hover:bg-amber-500/10"
+                  asChild
+                >
+                  <Link href={editHref}>
+                    <Pencil className="mr-1.5 h-3.5 w-3.5" />
+                    Edit Profile
+                  </Link>
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-white/20 text-gray-300 hover:bg-white/5"
+                  asChild
+                >
+                  <Link href="/dj/analytics">
+                    <ChartLine className="mr-1.5 h-3.5 w-3.5" />
+                    View Analytics
+                  </Link>
+                </Button>
+              </>
             ) : (
               <>
                 {viewMode === "fan" && !isNaN(djProfileId) ? (
@@ -312,6 +326,11 @@ function DjProfileStats({
           icon: CalendarDays,
         },
         {
+          val: formatNumber(dj.profileViews),
+          label: "Monthly Views",
+          icon: Eye,
+        },
+        {
           val: `${dj.responseRate}%`,
           label: "Response Rate",
           icon: Zap,
@@ -322,11 +341,6 @@ function DjProfileStats({
           label: "Booking Rate",
           icon: Handshake,
           green: true,
-        },
-        {
-          val: formatNumber(dj.profileViews),
-          label: "Monthly Views",
-          icon: Eye,
         },
       ]
     : [
@@ -344,6 +358,11 @@ function DjProfileStats({
           val: dj.eventsCount.toString(),
           label: "Events",
           icon: CalendarDays,
+        },
+        {
+          val: formatNumber(dj.profileViews),
+          label: "Monthly Views",
+          icon: Eye,
         },
       ];
 

--- a/src/components/dj-profile/DjProfilePremium.tsx
+++ b/src/components/dj-profile/DjProfilePremium.tsx
@@ -585,42 +585,91 @@ export default function DjProfilePremium({
     }
   }
 
-  const DJ = djData ? mapPremiumDjToProps(djData) : PREMIUM_DEFAULT_DJ;
+  const isStaging = process.env.NEXT_PUBLIC_APP_ENV === "staging";
+  const isProduction = process.env.NEXT_PUBLIC_APP_ENV === "production";
+
+  // In staging: use real data if available, supplement with demo data
+  // In production: only use real data
+  const DJ = djData
+    ? mapPremiumDjToProps(djData)
+    : isStaging
+      ? PREMIUM_DEFAULT_DJ
+      : null;
   const EVENTS = djData
     ? mapPremiumEventsFromData(djData)
-    : PREMIUM_DEFAULT_EVENTS;
-  const REVIEWS = djData ? mapPremiumReviewsFromData(djData) : [];
+    : isStaging
+      ? PREMIUM_DEFAULT_EVENTS
+      : [];
+  const REVIEWS = djData
+    ? mapPremiumReviewsFromData(djData)
+    : isStaging
+      ? PREMIUM_DEFAULT_REVIEWS
+      : [];
   const MEDIA = djData
     ? mapPremiumMediaFromData(djData)
-    : PREMIUM_DEFAULT_MEDIA;
+    : isStaging
+      ? PREMIUM_DEFAULT_MEDIA
+      : [];
   const ENDORSEMENTS = djData
     ? mapEndorsementsFromData(djData)
-    : PREMIUM_DEFAULT_ENDORSEMENTS;
+    : isStaging
+      ? PREMIUM_DEFAULT_ENDORSEMENTS
+      : [];
   const HIGHLIGHTS = djData
     ? mapHighlightsFromData(djData)
-    : PREMIUM_DEFAULT_HIGHLIGHTS;
-  const PRESS = djData ? mapPressFromData(djData) : PREMIUM_DEFAULT_PRESS;
+    : isStaging
+      ? PREMIUM_DEFAULT_HIGHLIGHTS
+      : [];
+  const PRESS = djData
+    ? mapPressFromData(djData)
+    : isStaging
+      ? PREMIUM_DEFAULT_PRESS
+      : [];
   const PACKAGES = djData
     ? mapPackagesFromData(djData)
-    : PREMIUM_DEFAULT_PACKAGES;
+    : isStaging
+      ? PREMIUM_DEFAULT_PACKAGES
+      : [];
   const CALENDAR_DAYS = djData
     ? buildCalendarFromData(djData)
-    : PREMIUM_DEFAULT_CALENDAR_DAYS;
-  const MIXES = djData ? mapMixesFromData(djData) : PREMIUM_DEFAULT_MIXES;
+    : isStaging
+      ? PREMIUM_DEFAULT_CALENDAR_DAYS
+      : [];
+  const MIXES = djData
+    ? mapMixesFromData(djData)
+    : isStaging
+      ? PREMIUM_DEFAULT_MIXES
+      : [];
   const calendarLabel = djData
     ? getCalendarMonthLabel(djData)
-    : "September 2025";
-  const SPOTLIGHT = djData ? djData.spotlight : PREMIUM_DEFAULT_SPOTLIGHT;
-  const featuredVideoUrl = SPOTLIGHT.featuredVideo.videoUrl;
+    : isStaging
+      ? "September 2025"
+      : "";
+  const SPOTLIGHT = djData
+    ? djData.spotlight
+    : isStaging
+      ? PREMIUM_DEFAULT_SPOTLIGHT
+      : null;
+  const featuredVideoUrl = SPOTLIGHT?.featuredVideo.videoUrl ?? "";
   const featuredVideoThumb =
-    SPOTLIGHT.featuredVideo.thumbnail ||
+    SPOTLIGHT?.featuredVideo.thumbnail ||
     getVideoThumbnailUrl(featuredVideoUrl) ||
     "/gallery-2.png";
-  const featuredMixAudioUrl = SPOTLIGHT.featuredMix.audioUrl;
+  const featuredMixAudioUrl = SPOTLIGHT?.featuredMix.audioUrl ?? "";
   const autoMixThumb = useAudioThumbnail(featuredMixAudioUrl);
   const featuredMixThumb =
-    SPOTLIGHT.featuredMix.thumbnail || autoMixThumb || "/gallery-2.png";
-  const location = `${DJ.city}, ${DJ.country}`;
+    SPOTLIGHT?.featuredMix.thumbnail || autoMixThumb || "/gallery-2.png";
+  const location = DJ ? `${DJ.city}, ${DJ.country}` : "";
+
+  // Early return in production if no data available
+  if (!DJ && isProduction) {
+    return null;
+  }
+
+  // After this point, DJ and SPOTLIGHT are guaranteed to be non-null
+  // (either from real data or demo defaults in staging)
+  const safeDJ = DJ!;
+  const safeSPOTLIGHT = SPOTLIGHT!;
 
   const bookingContext: BookingViewerContext = viewerContext ?? {
     role: "guest",
@@ -655,20 +704,20 @@ export default function DjProfilePremium({
             {/* ── MOBILE BOOK CTA ── */}
             <BookCTA
               ref={bookCTARefMobile}
-              stageName={`Dj. ${DJ.stageName}`}
+              stageName={`Dj. ${safeDJ.stageName}`}
               djProfileId={djProfileId}
               viewer={bookingContext}
               variant="premium"
               layout="mobile"
-              responseRate={DJ.responseRate}
-              bookingSuccessRate={DJ.bookingSuccessRate}
+              responseRate={safeDJ.responseRate}
+              bookingSuccessRate={safeDJ.bookingSuccessRate}
               bookingOptions={bookingOptions}
             />
 
             <div id="about">
               <ProfileAbout
-                bio={DJ.bio}
-                djTypes={DJ.djTypes}
+                bio={safeDJ.bio}
+                djTypes={safeDJ.djTypes}
                 bioExpanded={bioExpanded}
                 onToggleBio={() => setBioExpanded(!bioExpanded)}
                 experienceYears={djData?.experienceYears}
@@ -704,7 +753,7 @@ export default function DjProfilePremium({
                 }
                 calendarLabel={calendarLabel}
                 isOwner={isOwner}
-                djName={DJ.stageName}
+                djName={safeDJ.stageName}
                 featuredPerformanceUrl={djData?.featuredPerformanceUrl}
                 featuredPerformanceContext={djData?.featuredPerformanceContext}
                 featuredPerformanceThumbnailUrl={
@@ -713,102 +762,6 @@ export default function DjProfilePremium({
               />
             </div>
 
-            <Separator className="bg-white/8" />
-
-            {/* ── PERFORMANCE INSIGHTS (owner-only in fan view) ── */}
-            <OwnerOnlySection viewMode={viewMode}>
-              <section>
-                <SectionHeading sub="Last 30 days · Premium analytics">
-                  Performance Insights
-                </SectionHeading>
-                <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
-                  <StatPill value="3,240" label="Profile Views" trend="+24%" />
-                  <StatPill value="47" label="Booking Requests" trend="+18%" />
-                  <StatPill value="+312" label="New Followers" trend="+9%" />
-                  <StatPill value="94%" label="Booking Rate" />
-                </div>
-                <Card className="bg-h_blackLight/30 gap-0 border-white/8 p-5">
-                  <h3 className="mb-4 text-sm font-semibold text-white">
-                    Top Cities (Audience)
-                  </h3>
-                  <div className="flex flex-col gap-3">
-                    {[
-                      { city: "London", pct: 28 },
-                      { city: "Lagos", pct: 22 },
-                      { city: "Berlin", pct: 17 },
-                      { city: "New York", pct: 13 },
-                      { city: "Ibiza", pct: 10 },
-                    ].map((c) => (
-                      <div key={c.city} className="flex items-center gap-3">
-                        <span className="w-20 shrink-0 text-xs text-gray-400">
-                          {c.city}
-                        </span>
-                        <Progress
-                          value={c.pct}
-                          className="h-1.5 flex-1 bg-white/8"
-                        />
-                        <span className="w-8 text-right text-xs text-gray-500">
-                          {c.pct}%
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                </Card>
-                <div className="mt-3 grid gap-3 sm:grid-cols-2">
-                  <Card className="bg-h_blackLight/30 gap-0 border-white/8 p-4">
-                    <h3 className="mb-3 text-xs font-semibold tracking-wider text-gray-400 uppercase">
-                      Audience Age
-                    </h3>
-                    {[
-                      ["18–24", 35],
-                      ["25–34", 44],
-                      ["35–44", 16],
-                      ["45+", 5],
-                    ].map(([g, v]) => (
-                      <div key={g} className="mb-1.5 flex items-center gap-2">
-                        <span className="w-12 shrink-0 text-xs text-gray-400">
-                          {g}
-                        </span>
-                        <Progress
-                          value={Number(v)}
-                          className="h-1 flex-1 bg-white/8"
-                        />
-                        <span className="w-7 text-right text-xs text-gray-500">
-                          {v}%
-                        </span>
-                      </div>
-                    ))}
-                  </Card>
-                  <Card className="bg-h_blackLight/30 gap-0 border-white/8 p-4">
-                    <h3 className="mb-3 text-xs font-semibold tracking-wider text-gray-400 uppercase">
-                      Profile Traffic
-                    </h3>
-                    {[
-                      ["Direct", 42],
-                      ["Search", 31],
-                      ["Social", 18],
-                      ["Referral", 9],
-                    ].map(([src, v]) => (
-                      <div key={src} className="mb-1.5 flex items-center gap-2">
-                        <span className="w-14 shrink-0 text-xs text-gray-400">
-                          {src}
-                        </span>
-                        <Progress
-                          value={Number(v)}
-                          className="h-1 flex-1 bg-white/8"
-                        />
-                        <span className="w-7 text-right text-xs text-gray-500">
-                          {v}%
-                        </span>
-                      </div>
-                    ))}
-                  </Card>
-                </div>
-              </section>
-            </OwnerOnlySection>
-
-            <Separator className="bg-white/8" />
-
             {/* ── EXTENDED MEDIA LIBRARY ── */}
             <section id="media">
               <SectionHeading sub="Full media library · Unlimited with Premium">
@@ -816,97 +769,100 @@ export default function DjProfilePremium({
               </SectionHeading>
 
               {/* ── SPOTLIGHT (nested inside Media) ── */}
-              {(SPOTLIGHT.featuredMix.audioUrl ||
-                SPOTLIGHT.featuredVideo.videoUrl) && (
-                <>
-                  <h3 className="mb-4 text-sm font-semibold text-gray-400">
-                    Spotlight
-                  </h3>
-                  <div className="mb-8 flex flex-nowrap gap-4 overflow-x-auto pb-2 sm:grid sm:grid-cols-2 sm:overflow-visible lg:grid">
-                    {SPOTLIGHT.featuredMix.audioUrl && (
-                      <MediaAudioPlayer
-                        audioUrl={SPOTLIGHT.featuredMix.audioUrl}
-                        title={SPOTLIGHT.featuredMix.title}
-                        thumbnailUrl={featuredMixThumb || undefined}
-                        mediaId={SPOTLIGHT.featuredMix.id}
-                      >
-                        <Card className="bg-h_blackLight/30 group h-full min-w-72 cursor-pointer gap-0 overflow-hidden border-white/8 transition-all hover:border-amber-500/30 sm:min-w-0">
-                          <div className="from-h_red/20 relative h-44 bg-linear-to-br to-black">
-                            {featuredMixThumb ? (
+              {safeSPOTLIGHT &&
+                (safeSPOTLIGHT.featuredMix.audioUrl ||
+                  safeSPOTLIGHT.featuredVideo.videoUrl) && (
+                  <>
+                    <h3 className="mb-4 text-sm font-semibold text-gray-400">
+                      Spotlight
+                    </h3>
+                    <div className="mb-8 flex flex-nowrap gap-4 overflow-x-auto pb-2 sm:grid sm:grid-cols-2 sm:overflow-visible lg:grid">
+                      {safeSPOTLIGHT.featuredMix.audioUrl && (
+                        <MediaAudioPlayer
+                          audioUrl={safeSPOTLIGHT.featuredMix.audioUrl}
+                          title={safeSPOTLIGHT.featuredMix.title}
+                          thumbnailUrl={featuredMixThumb || undefined}
+                          mediaId={safeSPOTLIGHT.featuredMix.id}
+                        >
+                          <Card className="bg-h_blackLight/30 group h-full min-w-72 cursor-pointer gap-0 overflow-hidden border-white/8 transition-all hover:border-amber-500/30 sm:min-w-0">
+                            <div className="from-h_red/20 relative h-44 bg-linear-to-br to-black">
+                              {featuredMixThumb ? (
+                                <Image
+                                  src={featuredMixThumb}
+                                  alt={safeSPOTLIGHT.featuredMix.title}
+                                  fill
+                                  className="object-cover opacity-50 transition-opacity group-hover:opacity-60"
+                                />
+                              ) : null}
+                              <div className="absolute inset-0 flex items-center justify-center">
+                                <div className="bg-h_red/20 border-h_red/30 group-hover:bg-h_red/30 flex size-14 items-center justify-center rounded-full border transition-colors">
+                                  <Play className="ml-0.5 h-5 w-5 text-white" />
+                                </div>
+                              </div>
+                              <div className="absolute bottom-3 left-3">
+                                <Badge className="border-white/10 bg-black/60 text-[11px] text-gray-300">
+                                  <Headphones className="mr-1 h-2.5 w-2.5" />
+                                  Featured Mix
+                                </Badge>
+                              </div>
+                            </div>
+                            <div className="p-4">
+                              <p className="text-sm font-semibold text-white">
+                                {safeSPOTLIGHT.featuredMix.title}
+                              </p>
+                              <p className="mt-1 text-xs text-gray-500">
+                                {safeSPOTLIGHT.featuredMix.duration} ·{" "}
+                                {formatPlays(safeSPOTLIGHT.featuredMix.plays)}{" "}
+                                plays
+                              </p>
+                            </div>
+                          </Card>
+                        </MediaAudioPlayer>
+                      )}
+                      {safeSPOTLIGHT.featuredVideo.videoUrl && (
+                        <MediaVideoModal
+                          videoUrl={safeSPOTLIGHT.featuredVideo.videoUrl}
+                          thumbnail={featuredVideoThumb}
+                          title={safeSPOTLIGHT.featuredVideo.title}
+                          mediaId={safeSPOTLIGHT.featuredVideo.id}
+                        >
+                          <Card className="bg-h_blackLight/30 group h-full min-w-72 cursor-pointer gap-0 overflow-hidden border-white/8 transition-all hover:border-amber-500/30 sm:min-w-0">
+                            <div className="relative h-44 overflow-hidden">
                               <Image
-                                src={featuredMixThumb}
-                                alt={SPOTLIGHT.featuredMix.title}
+                                src={featuredVideoThumb}
+                                alt="video"
                                 fill
-                                className="object-cover opacity-50 transition-opacity group-hover:opacity-60"
+                                className="object-cover opacity-60 transition-all duration-500 group-hover:scale-105 group-hover:opacity-70"
                               />
-                            ) : null}
-                            <div className="absolute inset-0 flex items-center justify-center">
-                              <div className="bg-h_red/20 border-h_red/30 group-hover:bg-h_red/30 flex size-14 items-center justify-center rounded-full border transition-colors">
-                                <Play className="ml-0.5 h-5 w-5 text-white" />
+                              <div className="absolute inset-0 bg-linear-to-t from-black/60 to-transparent" />
+                              <div className="absolute inset-0 flex items-center justify-center">
+                                <div className="flex size-14 items-center justify-center rounded-full border border-white/20 bg-black/50 transition-colors group-hover:bg-black/70">
+                                  <Play className="ml-0.5 h-5 w-5 text-white" />
+                                </div>
+                              </div>
+                              <div className="absolute bottom-3 left-3">
+                                <Badge className="border-white/10 bg-black/60 text-[11px] text-gray-300">
+                                  <Video className="mr-1 h-2.5 w-2.5" />
+                                  Featured Video
+                                </Badge>
                               </div>
                             </div>
-                            <div className="absolute bottom-3 left-3">
-                              <Badge className="border-white/10 bg-black/60 text-[11px] text-gray-300">
-                                <Headphones className="mr-1 h-2.5 w-2.5" />
-                                Featured Mix
-                              </Badge>
+                            <div className="p-4">
+                              <p className="text-sm font-semibold text-white">
+                                {safeSPOTLIGHT.featuredVideo.title}
+                              </p>
+                              <p className="mt-1 text-xs text-gray-500">
+                                {safeSPOTLIGHT.featuredVideo.duration} ·{" "}
+                                {formatPlays(safeSPOTLIGHT.featuredVideo.views)}{" "}
+                                views
+                              </p>
                             </div>
-                          </div>
-                          <div className="p-4">
-                            <p className="text-sm font-semibold text-white">
-                              {SPOTLIGHT.featuredMix.title}
-                            </p>
-                            <p className="mt-1 text-xs text-gray-500">
-                              {SPOTLIGHT.featuredMix.duration} ·{" "}
-                              {formatPlays(SPOTLIGHT.featuredMix.plays)} plays
-                            </p>
-                          </div>
-                        </Card>
-                      </MediaAudioPlayer>
-                    )}
-                    {SPOTLIGHT.featuredVideo.videoUrl && (
-                      <MediaVideoModal
-                        videoUrl={SPOTLIGHT.featuredVideo.videoUrl}
-                        thumbnail={featuredVideoThumb}
-                        title={SPOTLIGHT.featuredVideo.title}
-                        mediaId={SPOTLIGHT.featuredVideo.id}
-                      >
-                        <Card className="bg-h_blackLight/30 group h-full min-w-72 cursor-pointer gap-0 overflow-hidden border-white/8 transition-all hover:border-amber-500/30 sm:min-w-0">
-                          <div className="relative h-44 overflow-hidden">
-                            <Image
-                              src={featuredVideoThumb}
-                              alt="video"
-                              fill
-                              className="object-cover opacity-60 transition-all duration-500 group-hover:scale-105 group-hover:opacity-70"
-                            />
-                            <div className="absolute inset-0 bg-linear-to-t from-black/60 to-transparent" />
-                            <div className="absolute inset-0 flex items-center justify-center">
-                              <div className="flex size-14 items-center justify-center rounded-full border border-white/20 bg-black/50 transition-colors group-hover:bg-black/70">
-                                <Play className="ml-0.5 h-5 w-5 text-white" />
-                              </div>
-                            </div>
-                            <div className="absolute bottom-3 left-3">
-                              <Badge className="border-white/10 bg-black/60 text-[11px] text-gray-300">
-                                <Video className="mr-1 h-2.5 w-2.5" />
-                                Featured Video
-                              </Badge>
-                            </div>
-                          </div>
-                          <div className="p-4">
-                            <p className="text-sm font-semibold text-white">
-                              {SPOTLIGHT.featuredVideo.title}
-                            </p>
-                            <p className="mt-1 text-xs text-gray-500">
-                              {SPOTLIGHT.featuredVideo.duration} ·{" "}
-                              {formatPlays(SPOTLIGHT.featuredVideo.views)} views
-                            </p>
-                          </div>
-                        </Card>
-                      </MediaVideoModal>
-                    )}
-                  </div>
-                </>
-              )}
+                          </Card>
+                        </MediaVideoModal>
+                      )}
+                    </div>
+                  </>
+                )}
 
               <div className="mb-4 flex gap-2">
                 {(["photos", "videos", "mixes"] as const).map((tab) => (
@@ -1088,8 +1044,8 @@ export default function DjProfilePremium({
                   </SectionHeading>
                   {REVIEWS.length > 0 ? (
                     <ProfileReviews
-                      avgRating={DJ.avgRating}
-                      ratingCount={DJ.ratingCount}
+                      avgRating={safeDJ.avgRating}
+                      ratingCount={safeDJ.ratingCount}
                       reviews={REVIEWS}
                     />
                   ) : (
@@ -1184,13 +1140,13 @@ export default function DjProfilePremium({
             {/* Priority Booking CTA — desktop only; mobile version is inline above */}
             <BookCTA
               ref={bookCTARefDesktop}
-              stageName={`Dj. ${DJ.stageName}`}
+              stageName={`Dj. ${safeDJ.stageName}`}
               djProfileId={djProfileId}
               viewer={bookingContext}
               variant="premium"
               layout="desktop"
-              responseRate={DJ.responseRate}
-              bookingSuccessRate={DJ.bookingSuccessRate}
+              responseRate={safeDJ.responseRate}
+              bookingSuccessRate={safeDJ.bookingSuccessRate}
               bookingOptions={bookingOptions}
             />
 
@@ -1199,18 +1155,18 @@ export default function DjProfilePremium({
               <ProfileEventsSidebar
                 events={EVENTS}
                 isOwner={isOwner}
-                djName={DJ.stageName}
+                djName={safeDJ.stageName}
               />
             </div>
             <Separator className="bg-white/8" /> */}
 
             {/* Professional Team */}
             <ProfessionalTeamSidebar
-              managerName={DJ.manager.name}
-              managerEmail={DJ.manager.email}
-              agentName={DJ.agent.name}
-              agentAgency={DJ.agent.agency}
-              agentEmail={DJ.agent.email}
+              managerName={safeDJ.manager.name}
+              managerEmail={safeDJ.manager.email}
+              agentName={safeDJ.agent.name}
+              agentAgency={safeDJ.agent.agency}
+              agentEmail={safeDJ.agent.email}
             />
 
             <Separator className="bg-white/8" />
@@ -1222,10 +1178,10 @@ export default function DjProfilePremium({
               </h3>
               <div className="mb-1 flex items-end gap-2">
                 <span className="text-2xl font-bold text-white">
-                  {DJ.minFee}
+                  {safeDJ.minFee}
                 </span>
                 <span className="mb-0.5 text-sm text-gray-500">
-                  – {DJ.maxFee}
+                  – {safeDJ.maxFee}
                 </span>
               </div>
               <p className="text-xs text-gray-500">

--- a/src/components/dj-profile/DjProfilePremium.tsx
+++ b/src/components/dj-profile/DjProfilePremium.tsx
@@ -1198,11 +1198,25 @@ export default function DjProfilePremium({
                     This Month
                   </h3>
                 </div>
-                {[
-                  { label: "Profile Views", val: "3,240", trend: "+24%" },
-                  { label: "Booking Requests", val: "47", trend: "+18%" },
-                  { label: "New Followers", val: "312", trend: "+9%" },
-                ].map((m) => (
+                {(
+                  [
+                    {
+                      label: "Profile Views",
+                      val: djData?.analytics.profileViews.value ?? 0,
+                      growth: djData?.analytics.profileViews.growth ?? 0,
+                    },
+                    {
+                      label: "Booking Requests",
+                      val: djData?.analytics.bookingRequests.value ?? 0,
+                      growth: djData?.analytics.bookingRequests.growth ?? 0,
+                    },
+                    {
+                      label: "New Followers",
+                      val: djData?.analytics.newFollowers.value ?? 0,
+                      growth: djData?.analytics.newFollowers.growth ?? 0,
+                    },
+                  ] as const
+                ).map((m) => (
                   <div
                     key={m.label}
                     className="mb-2 flex items-center justify-between"
@@ -1210,10 +1224,17 @@ export default function DjProfilePremium({
                     <span className="text-xs text-gray-400">{m.label}</span>
                     <div className="flex items-center gap-1.5">
                       <span className="text-xs font-semibold text-white">
-                        {m.val}
+                        {m.val.toLocaleString()}
                       </span>
-                      <span className="text-[11px] text-emerald-400">
-                        {m.trend}
+                      <span
+                        className={
+                          m.growth >= 0
+                            ? "text-[11px] text-emerald-400"
+                            : "text-[11px] text-red-400"
+                        }
+                      >
+                        {m.growth >= 0 ? "+" : ""}
+                        {m.growth}%
                       </span>
                     </div>
                   </div>

--- a/src/components/dj/DjAnalyticsDashboard.tsx
+++ b/src/components/dj/DjAnalyticsDashboard.tsx
@@ -11,6 +11,7 @@ import {
   ArrowUpRight,
   Music2,
   TrendingUp,
+  MapPin,
 } from "lucide-react";
 import {
   LineChart,
@@ -35,7 +36,9 @@ import type {
   BookingStatusCount,
   TopMediaItem,
   ProfileViewSource,
+  TopCity,
 } from "@/lib/queries/dj-stats";
+import { hasFeature, type DjPlanTier } from "@/lib/plan-features";
 
 const BRAND_RED = "#d30101";
 const BRAND_RED_DARK = "#a80000";
@@ -93,29 +96,36 @@ const ChartTooltip = ({
 
 type Props = {
   slug: string | null;
+  plan: DjPlanTier;
   totals: {
     followers: number;
     bookings: number;
     profileViews: number;
     mediaPlays: number;
     mediaViews: number;
+    responseRate: number;
+    bookingRate: number;
   };
   viewsOverTime: DailyCount[];
   followersOverTime: DailyCount[];
   bookingsByStatus: BookingStatusCount[];
   topMedia: TopMediaItem[];
   sources: ProfileViewSource[];
+  topCities: TopCity[];
 };
 
 export default function DjAnalyticsDashboard({
   slug,
+  plan,
   totals,
   viewsOverTime,
   followersOverTime,
   bookingsByStatus,
   topMedia,
   sources,
+  topCities,
 }: Props) {
+  const hasAdvancedAnalytics = hasFeature(plan, "advancedAnalyticsAccess");
   const totalViews = viewsOverTime.reduce((sum, d) => sum + d.count, 0);
   const totalFollowers = followersOverTime.reduce((sum, d) => sum + d.count, 0);
   const hasData =
@@ -132,7 +142,8 @@ export default function DjAnalyticsDashboard({
         <div>
           <h2 className="text-lg font-semibold text-white">Analytics</h2>
           <p className="text-muted-foreground mt-0.5 text-sm">
-            Track your profile and content performance over the last 30 days
+            Track your profile and content performance over the last{" "}
+            {hasAdvancedAnalytics ? "30" : "7"} days
           </p>
         </div>
         {slug && (
@@ -189,26 +200,22 @@ export default function DjAnalyticsDashboard({
         <Card size="sm" className="flex flex-col justify-end">
           <CardHeader>
             <CardTitle className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
-              Plays
+              Response Rate
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-3xl font-bold">
-              {formatNumber(totals.mediaPlays)}
-            </p>
+            <p className="text-3xl font-bold">{totals.responseRate}%</p>
           </CardContent>
         </Card>
 
         <Card size="sm" className="flex flex-col justify-end">
           <CardHeader>
             <CardTitle className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
-              Video Views
+              Booking Rate
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-3xl font-bold">
-              {formatNumber(totals.mediaViews)}
-            </p>
+            <p className="text-3xl font-bold">{totals.bookingRate}%</p>
           </CardContent>
         </Card>
       </div>
@@ -232,116 +239,29 @@ export default function DjAnalyticsDashboard({
         <>
           <Separator />
 
-          {/* Charts row */}
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-            {/* Profile views over time */}
-            <Card className="border-white/10 bg-white/5">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-sm font-semibold text-white">
-                  <Eye className="text-h_red h-4 w-4" />
-                  Profile Views (30 days)
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="h-64 w-full">
-                  <ResponsiveContainer width="100%" height="100%">
-                    <LineChart data={viewsOverTime}>
-                      <CartesianGrid stroke={GRID} vertical={false} />
-                      <XAxis
-                        dataKey="date"
-                        tick={{ fill: GRAY, fontSize: 11 }}
-                        tickFormatter={formatDate}
-                        axisLine={{ stroke: GRID }}
-                        tickLine={false}
-                        minTickGap={24}
-                      />
-                      <YAxis
-                        tick={{ fill: GRAY, fontSize: 11 }}
-                        axisLine={false}
-                        tickLine={false}
-                        allowDecimals={false}
-                      />
-                      <Tooltip content={<ChartTooltip />} />
-                      <Line
-                        type="monotone"
-                        dataKey="count"
-                        stroke={BRAND_RED}
-                        strokeWidth={2}
-                        dot={{ r: 3, fill: BRAND_RED, strokeWidth: 0 }}
-                        activeDot={{ r: 5, fill: BRAND_RED }}
-                      />
-                    </LineChart>
-                  </ResponsiveContainer>
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Follower growth over time */}
-            <Card className="border-white/10 bg-white/5">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-sm font-semibold text-white">
-                  <Users className="text-h_red h-4 w-4" />
-                  New Followers (30 days)
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="h-64 w-full">
-                  <ResponsiveContainer width="100%" height="100%">
-                    <LineChart data={followersOverTime}>
-                      <CartesianGrid stroke={GRID} vertical={false} />
-                      <XAxis
-                        dataKey="date"
-                        tick={{ fill: GRAY, fontSize: 11 }}
-                        tickFormatter={formatDate}
-                        axisLine={{ stroke: GRID }}
-                        tickLine={false}
-                        minTickGap={24}
-                      />
-                      <YAxis
-                        tick={{ fill: GRAY, fontSize: 11 }}
-                        axisLine={false}
-                        tickLine={false}
-                        allowDecimals={false}
-                      />
-                      <Tooltip content={<ChartTooltip />} />
-                      <Line
-                        type="monotone"
-                        dataKey="count"
-                        stroke={BRAND_RED_DARK}
-                        strokeWidth={2}
-                        dot={{ r: 3, fill: BRAND_RED_DARK, strokeWidth: 0 }}
-                        activeDot={{ r: 5, fill: BRAND_RED_DARK }}
-                      />
-                    </LineChart>
-                  </ResponsiveContainer>
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Booking status breakdown */}
-            <Card className="border-white/10 bg-white/5">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-sm font-semibold text-white">
-                  <Handshake className="text-h_red h-4 w-4" />
-                  Booking Requests by Status
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                {bookingsByStatus.length === 0 ? (
-                  <p className="text-muted-foreground py-8 text-center text-sm">
-                    No booking requests yet
-                  </p>
-                ) : (
+          {/* Charts row - only show advanced charts for PREMIUM */}
+          {hasAdvancedAnalytics ? (
+            <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+              {/* Profile views over time */}
+              <Card className="border-white/10 bg-white/5">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-sm font-semibold text-white">
+                    <Eye className="text-h_red h-4 w-4" />
+                    Profile Views (30 days)
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
                   <div className="h-64 w-full">
                     <ResponsiveContainer width="100%" height="100%">
-                      <BarChart data={bookingsByStatus}>
+                      <LineChart data={viewsOverTime}>
                         <CartesianGrid stroke={GRID} vertical={false} />
                         <XAxis
-                          dataKey="status"
-                          tickFormatter={(v) => STATUS_LABELS[v] || v}
+                          dataKey="date"
                           tick={{ fill: GRAY, fontSize: 11 }}
+                          tickFormatter={formatDate}
                           axisLine={{ stroke: GRID }}
                           tickLine={false}
+                          minTickGap={24}
                         />
                         <YAxis
                           tick={{ fill: GRAY, fontSize: 11 }}
@@ -349,113 +269,280 @@ export default function DjAnalyticsDashboard({
                           tickLine={false}
                           allowDecimals={false}
                         />
-                        <Tooltip
-                          content={({ active, payload, label }) => {
-                            if (active && payload && payload.length) {
-                              return (
-                                <div className="rounded-md border border-white/10 bg-black/90 px-3 py-2 text-xs text-white shadow-lg">
-                                  <p className="text-gray-400">
-                                    {STATUS_LABELS[String(label)] || label}
-                                  </p>
-                                  <p className="font-medium">
-                                    {payload[0].value}
-                                  </p>
-                                </div>
-                              );
-                            }
-                            return null;
-                          }}
+                        <Tooltip content={<ChartTooltip />} />
+                        <Line
+                          type="monotone"
+                          dataKey="count"
+                          stroke={BRAND_RED}
+                          strokeWidth={2}
+                          dot={{ r: 3, fill: BRAND_RED, strokeWidth: 0 }}
+                          activeDot={{ r: 5, fill: BRAND_RED }}
                         />
-                        <Bar dataKey="count" radius={[4, 4, 0, 0]}>
-                          {bookingsByStatus.map((_, i) => (
-                            <Cell
-                              key={`cell-${i}`}
-                              fill={CHART_COLORS[i % CHART_COLORS.length]}
-                            />
-                          ))}
-                        </Bar>
-                      </BarChart>
+                      </LineChart>
                     </ResponsiveContainer>
                   </div>
-                )}
-              </CardContent>
-            </Card>
+                </CardContent>
+              </Card>
 
-            {/* Traffic sources */}
-            <Card className="border-white/10 bg-white/5">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-sm font-semibold text-white">
-                  <TrendingUp className="text-h_red h-4 w-4" />
-                  Profile View Sources
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                {sources.length === 0 ? (
-                  <p className="text-muted-foreground py-8 text-center text-sm">
-                    No source data yet
-                  </p>
-                ) : (
+              {/* Follower growth over time */}
+              <Card className="border-white/10 bg-white/5">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-sm font-semibold text-white">
+                    <Users className="text-h_red h-4 w-4" />
+                    New Followers (30 days)
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
                   <div className="h-64 w-full">
                     <ResponsiveContainer width="100%" height="100%">
-                      <PieChart>
-                        <Pie
-                          data={sources}
+                      <LineChart data={followersOverTime}>
+                        <CartesianGrid stroke={GRID} vertical={false} />
+                        <XAxis
+                          dataKey="date"
+                          tick={{ fill: GRAY, fontSize: 11 }}
+                          tickFormatter={formatDate}
+                          axisLine={{ stroke: GRID }}
+                          tickLine={false}
+                          minTickGap={24}
+                        />
+                        <YAxis
+                          tick={{ fill: GRAY, fontSize: 11 }}
+                          axisLine={false}
+                          tickLine={false}
+                          allowDecimals={false}
+                        />
+                        <Tooltip content={<ChartTooltip />} />
+                        <Line
+                          type="monotone"
                           dataKey="count"
-                          nameKey="source"
-                          cx="50%"
-                          cy="50%"
-                          outerRadius={80}
-                          label={(props) => {
-                            const source = String(props.name ?? "");
-                            const count = Number(props.value ?? 0);
-                            return `${SOURCE_LABELS[source] || source}: ${count}`;
-                          }}
-                          labelLine={false}
-                        >
-                          {sources.map((_, i) => (
-                            <Cell
-                              key={`cell-${i}`}
-                              fill={CHART_COLORS[i % CHART_COLORS.length]}
-                            />
-                          ))}
-                        </Pie>
-                        <Legend
-                          verticalAlign="bottom"
-                          height={24}
-                          formatter={(value) => (
-                            <span className="text-xs text-gray-400">
-                              {SOURCE_LABELS[value] || value}
-                            </span>
-                          )}
+                          stroke={BRAND_RED_DARK}
+                          strokeWidth={2}
+                          dot={{ r: 3, fill: BRAND_RED_DARK, strokeWidth: 0 }}
+                          activeDot={{ r: 5, fill: BRAND_RED_DARK }}
                         />
-                        <Tooltip
-                          content={({ active, payload }) => {
-                            if (active && payload && payload.length) {
-                              const p = payload[0];
-                              const source = String(p.name);
-                              return (
-                                <div className="rounded-md border border-white/10 bg-black/90 px-3 py-2 text-xs text-white shadow-lg">
-                                  <p className="text-gray-400">
-                                    {SOURCE_LABELS[source] || source}
-                                  </p>
-                                  <p className="font-medium">{p.value}</p>
-                                </div>
-                              );
-                            }
-                            return null;
-                          }}
-                        />
-                      </PieChart>
+                      </LineChart>
                     </ResponsiveContainer>
                   </div>
-                )}
+                </CardContent>
+              </Card>
+
+              {/* Booking status breakdown */}
+              <Card className="border-white/10 bg-white/5">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-sm font-semibold text-white">
+                    <Handshake className="text-h_red h-4 w-4" />
+                    Booking Requests by Status
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {bookingsByStatus.length === 0 ? (
+                    <p className="text-muted-foreground py-8 text-center text-sm">
+                      No booking requests yet
+                    </p>
+                  ) : (
+                    <div className="h-64 w-full">
+                      <ResponsiveContainer width="100%" height="100%">
+                        <BarChart data={bookingsByStatus}>
+                          <CartesianGrid stroke={GRID} vertical={false} />
+                          <XAxis
+                            dataKey="status"
+                            tickFormatter={(v) => STATUS_LABELS[v] || v}
+                            tick={{ fill: GRAY, fontSize: 11 }}
+                            axisLine={{ stroke: GRID }}
+                            tickLine={false}
+                          />
+                          <YAxis
+                            tick={{ fill: GRAY, fontSize: 11 }}
+                            axisLine={false}
+                            tickLine={false}
+                            allowDecimals={false}
+                          />
+                          <Tooltip
+                            content={({ active, payload, label }) => {
+                              if (active && payload && payload.length) {
+                                return (
+                                  <div className="rounded-md border border-white/10 bg-black/90 px-3 py-2 text-xs text-white shadow-lg">
+                                    <p className="text-gray-400">
+                                      {STATUS_LABELS[String(label)] || label}
+                                    </p>
+                                    <p className="font-medium">
+                                      {payload[0].value}
+                                    </p>
+                                  </div>
+                                );
+                              }
+                              return null;
+                            }}
+                          />
+                          <Bar dataKey="count" radius={[4, 4, 0, 0]}>
+                            {bookingsByStatus.map((_, i) => (
+                              <Cell
+                                key={`cell-${i}`}
+                                fill={CHART_COLORS[i % CHART_COLORS.length]}
+                              />
+                            ))}
+                          </Bar>
+                        </BarChart>
+                      </ResponsiveContainer>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+
+              {/* Traffic sources */}
+              <Card className="border-white/10 bg-white/5">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-sm font-semibold text-white">
+                    <TrendingUp className="text-h_red h-4 w-4" />
+                    Profile View Sources
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {sources.length === 0 ? (
+                    <p className="text-muted-foreground py-8 text-center text-sm">
+                      No source data yet
+                    </p>
+                  ) : (
+                    <div className="h-64 w-full">
+                      <ResponsiveContainer width="100%" height="100%">
+                        <PieChart>
+                          <Pie
+                            data={sources}
+                            dataKey="count"
+                            nameKey="source"
+                            cx="50%"
+                            cy="50%"
+                            outerRadius={80}
+                            label={(props) => {
+                              const source = String(props.name ?? "");
+                              const count = Number(props.value ?? 0);
+                              return `${SOURCE_LABELS[source] || source}: ${count}`;
+                            }}
+                            labelLine={false}
+                          >
+                            {sources.map((_, i) => (
+                              <Cell
+                                key={`cell-${i}`}
+                                fill={CHART_COLORS[i % CHART_COLORS.length]}
+                              />
+                            ))}
+                          </Pie>
+                          <Legend
+                            verticalAlign="bottom"
+                            height={24}
+                            formatter={(value) => (
+                              <span className="text-xs text-gray-400">
+                                {SOURCE_LABELS[value] || value}
+                              </span>
+                            )}
+                          />
+                          <Tooltip
+                            content={({ active, payload }) => {
+                              if (active && payload && payload.length) {
+                                const p = payload[0];
+                                const source = String(p.name);
+                                return (
+                                  <div className="rounded-md border border-white/10 bg-black/90 px-3 py-2 text-xs text-white shadow-lg">
+                                    <p className="text-gray-400">
+                                      {SOURCE_LABELS[source] || source}
+                                    </p>
+                                    <p className="font-medium">{p.value}</p>
+                                  </div>
+                                );
+                              }
+                              return null;
+                            }}
+                          />
+                        </PieChart>
+                      </ResponsiveContainer>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+
+              {/* Top Cities — audience location from profile views */}
+              <Card className="border-white/10 bg-white/5">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-sm font-semibold text-white">
+                    <MapPin className="text-h_red h-4 w-4" />
+                    Top Cities
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {topCities.length === 0 ? (
+                    <p className="text-muted-foreground py-8 text-center text-sm">
+                      No location data yet
+                    </p>
+                  ) : (
+                    <div className="h-64 w-full">
+                      <ResponsiveContainer width="100%" height="100%">
+                        <BarChart data={topCities} layout="vertical">
+                          <CartesianGrid stroke={GRID} horizontal={false} />
+                          <XAxis
+                            type="number"
+                            tick={{ fill: GRAY, fontSize: 11 }}
+                            axisLine={false}
+                            tickLine={false}
+                            allowDecimals={false}
+                          />
+                          <YAxis
+                            type="category"
+                            dataKey="city"
+                            tick={{ fill: GRAY, fontSize: 11 }}
+                            axisLine={{ stroke: GRID }}
+                            tickLine={false}
+                            width={80}
+                          />
+                          <Tooltip
+                            content={({ active, payload, label }) => {
+                              if (active && payload && payload.length) {
+                                const item = payload[0].payload as TopCity;
+                                return (
+                                  <div className="rounded-md border border-white/10 bg-black/90 px-3 py-2 text-xs text-white shadow-lg">
+                                    <p className="text-gray-400">
+                                      {label}, {item.country}
+                                    </p>
+                                    <p className="font-medium">
+                                      {payload[0].value} views
+                                    </p>
+                                  </div>
+                                );
+                              }
+                              return null;
+                            }}
+                          />
+                          <Bar dataKey="count" radius={[0, 4, 4, 0]}>
+                            {topCities.map((_, i) => (
+                              <Cell
+                                key={`cell-${i}`}
+                                fill={CHART_COLORS[i % CHART_COLORS.length]}
+                              />
+                            ))}
+                          </Bar>
+                        </BarChart>
+                      </ResponsiveContainer>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          ) : (
+            <Card className="border-white/10 bg-white/5">
+              <CardContent className="py-12 text-center">
+                <TrendingUp className="mx-auto mb-3 h-8 w-8 text-gray-500" />
+                <h3 className="text-base font-semibold text-white">
+                  Upgrade to Premium for Advanced Analytics
+                </h3>
+                <p className="text-muted-foreground mt-1 text-sm">
+                  Get detailed charts, 30-day trends, and demographic insights
+                </p>
               </CardContent>
             </Card>
-          </div>
+          )}
 
           <Separator />
 
-          {/* Top media */}
+          {/* Top media - available for all plans */}
           <section>
             <h3 className="text-muted-foreground mb-4 text-sm font-semibold tracking-wider uppercase">
               Top Performing Media

--- a/src/lib/plan-features.ts
+++ b/src/lib/plan-features.ts
@@ -18,9 +18,13 @@ export interface PlanFeatures {
   // Profile features
   verifiedBadge: boolean;
   advancedProfileSections: boolean; // endorsements, press, packages
-  // Analytics & stats
-  analyticsAccess: boolean;
-  responseRateStats: boolean;
+  // Public stats (hero bar - visible to all viewers)
+  publicStatsAccess: boolean;
+  responseRateStats: boolean; // Show Response/Booking rate in hero
+  monthlyViews: boolean;
+  // Owner analytics (dashboard)
+  basicAnalyticsAccess: boolean; // Summary cards, 7-day data
+  advancedAnalyticsAccess: boolean; // Charts, 30/90-day data, demographics
   // Booking
   bookingInquiries: boolean; // ALL plans — never block inquiries
   availabilityCalendar: boolean;
@@ -35,8 +39,11 @@ export const PLAN_FEATURES: Record<DjPlanTier, PlanFeatures> = {
     prioritySearchRanking: false,
     verifiedBadge: false,
     advancedProfileSections: false,
-    analyticsAccess: false,
+    publicStatsAccess: true,
     responseRateStats: false,
+    monthlyViews: true,
+    basicAnalyticsAccess: true,
+    advancedAnalyticsAccess: false,
     bookingInquiries: true,
     availabilityCalendar: false,
     advancedBookingTools: false,
@@ -48,8 +55,11 @@ export const PLAN_FEATURES: Record<DjPlanTier, PlanFeatures> = {
     prioritySearchRanking: true,
     verifiedBadge: true,
     advancedProfileSections: true,
-    analyticsAccess: true,
+    publicStatsAccess: true,
     responseRateStats: true,
+    monthlyViews: true,
+    basicAnalyticsAccess: true,
+    advancedAnalyticsAccess: true,
     bookingInquiries: true,
     availabilityCalendar: true,
     advancedBookingTools: true,

--- a/src/lib/queries/dj-stats.ts
+++ b/src/lib/queries/dj-stats.ts
@@ -176,3 +176,68 @@ export async function getDjProfileViewSources(
     }))
     .sort((a, b) => b.count - a.count);
 }
+
+// ── Phase 1: Response Rate & Booking Rate ────────────────────────────────────
+// These replace the hardcoded values in seed data and profile defaults.
+// Response Rate = % of booking inquiries that received a response (ACCEPTED or DECLINED)
+// Booking Rate  = % of booking inquiries that were ACCEPTED
+
+export async function getDjResponseRate(djProfileId: number): Promise<number> {
+  const [total, responded] = await Promise.all([
+    prisma.bookingInquiry.count({
+      where: { djProfileId },
+    }),
+    prisma.bookingInquiry.count({
+      where: {
+        djProfileId,
+        status: { in: ["ACCEPTED", "DECLINED"] },
+      },
+    }),
+  ]);
+
+  return total > 0 ? Math.round((responded / total) * 100) : 0;
+}
+
+export async function getDjBookingRate(djProfileId: number): Promise<number> {
+  const [total, accepted] = await Promise.all([
+    prisma.bookingInquiry.count({
+      where: { djProfileId },
+    }),
+    prisma.bookingInquiry.count({
+      where: {
+        djProfileId,
+        status: "ACCEPTED",
+      },
+    }),
+  ]);
+
+  return total > 0 ? Math.round((accepted / total) * 100) : 0;
+}
+
+// ── Phase 2: Top Cities (audience location from ProfileView) ─────────────────
+// ProfileView already has `city` and `country` as String? fields.
+// We group by city to find where the DJ's audience is located.
+
+export type TopCity = { city: string; country: string; count: number };
+
+export async function getDjTopCities(
+  djProfileId: number,
+  limit = 5,
+): Promise<TopCity[]> {
+  const results = await prisma.profileView.groupBy({
+    by: ["city", "country"],
+    where: {
+      djProfileId,
+      city: { not: null },
+    },
+    _count: { city: true },
+    orderBy: { _count: { city: "desc" } },
+    take: limit,
+  });
+
+  return results.map((r) => ({
+    city: r.city || "Unknown",
+    country: r.country || "Unknown",
+    count: r._count.city,
+  }));
+}


### PR DESCRIPTION
…king to DJ profiles

- Add city and country fields to ProfileView model for geographic analytics
- Capture viewer location (city/country) when tracking profile views
- Add getDjResponseRate, getDjBookingRate, and getDjTopCities query functions
- Display response rate, booking rate, and top cities on DJ profile pages
- Add plan-based analytics access control (7-day for free, 30-day for premium)
- Show "View Analytics" button in profile hero