### PR TITLE
Implement CRUD operations for press items in DJ profile

### DIFF
--- a/src/app/djs/[slug]/page.tsx
+++ b/src/app/djs/[slug]/page.tsx
@@ -495,10 +495,12 @@ export default async function DjProfilePage({
       quote: e.quote,
     })),
     press: dj.pressItems.map((p) => ({
+      id: p.id,
       source: p.source,
       type: p.type,
       title: p.title,
       date: p.date ?? "",
+      url: p.url ?? "",
     })),
     venuesPlayed: (dj.venues || []).map((v) => ({
       id: v.id,

--- a/src/components/dj-profile/DjProfilePremium.tsx
+++ b/src/components/dj-profile/DjProfilePremium.tsx
@@ -613,6 +613,13 @@ export default function DjProfilePremium({
   async function handlePressSave(newPressItems: typeof pressItems) {
     const toastId = toast.loading("Saving press items...");
 
+    function normalizeUrl(url: string): string {
+      const trimmed = url.trim();
+      if (!trimmed) return "";
+      if (/^https?:\/\//i.test(trimmed)) return trimmed;
+      return `https://${trimmed}`;
+    }
+
     try {
       // IDs > 1000000000000 are temporary Date.now() IDs (new items not yet saved)
       const TEMP_ID_THRESHOLD = 1000000000000;
@@ -635,7 +642,8 @@ export default function DjProfilePremium({
         formData.append("type", item.type.trim());
         formData.append("title", item.title.trim());
         if (item.date.trim()) formData.append("date", item.date.trim());
-        if (item.url.trim()) formData.append("url", item.url.trim());
+        const normalizedUrl = normalizeUrl(item.url);
+        if (normalizedUrl) formData.append("url", normalizedUrl);
 
         const result = await createDjPressItem(formData);
         if ("error" in result) {
@@ -656,7 +664,8 @@ export default function DjProfilePremium({
         formData.append("type", item.type.trim());
         formData.append("title", item.title.trim());
         formData.append("date", item.date.trim());
-        formData.append("url", item.url.trim());
+        const normalizedUrl = normalizeUrl(item.url);
+        formData.append("url", normalizedUrl);
 
         const result = await updateDjPressItem(item.id, formData);
         if ("error" in result) {
@@ -678,9 +687,9 @@ export default function DjProfilePremium({
       const updatedItems = newPressItems.map((p) => {
         if (p.id > TEMP_ID_THRESHOLD && addedItemIds.length > 0) {
           const newId = addedItemIds.shift();
-          return { ...p, id: newId || 0 };
+          return { ...p, id: newId || 0, url: normalizeUrl(p.url) };
         }
-        return p;
+        return { ...p, url: normalizeUrl(p.url) };
       });
       setPressItems(updatedItems);
 

--- a/src/components/dj-profile/DjProfilePremium.tsx
+++ b/src/components/dj-profile/DjProfilePremium.tsx
@@ -23,6 +23,7 @@ import {
   Star,
   Plus,
   Pencil,
+  Newspaper,
 } from "lucide-react";
 import type { DjDemoData, ViewMode } from "@/types/dj-demo";
 import { DjProfileHero } from "@/components/dj-profile/DjProfileHero";
@@ -39,6 +40,7 @@ import DjProfileSubNav from "@/components/dj-profile/DjProfileSubNav";
 import DjProfileMobileBottomBar from "@/components/dj-profile/DjProfileMobileBottomBar";
 import VenueModal from "@/components/dj-profile/VenueModal";
 import HighlightModal from "@/components/dj-profile/HighlightModal";
+import PressModal from "@/components/dj-profile/PressModal";
 import BookingPackages from "@/components/dj-profile/BookingPackages";
 import PackageModal from "@/components/dj-profile/PackageModal";
 import ProfileEventsSidebar from "@/components/dj-profile/ProfileEventsSidebar";
@@ -57,6 +59,11 @@ import {
   updateDjHighlight,
   deleteDjHighlight,
 } from "@/lib/actions/dj-highlights";
+import {
+  createDjPressItem,
+  updateDjPressItem,
+  deleteDjPressItem,
+} from "@/lib/actions/dj-press";
 import { toast } from "sonner";
 import { ReputationBadge } from "@/components/dj-profile/ReputationBadge";
 import { ScoreBreakdown } from "@/components/dj-profile/ScoreBreakdown";
@@ -252,6 +259,26 @@ export default function DjProfilePremium({
   const [isVenueModalOpen, setIsVenueModalOpen] = useState(false);
   const [isPackageModalOpen, setIsPackageModalOpen] = useState(false);
   const [isHighlightModalOpen, setIsHighlightModalOpen] = useState(false);
+  const [isPressModalOpen, setIsPressModalOpen] = useState(false);
+  const [pressItems, setPressItems] = useState<
+    Array<{
+      id: number;
+      source: string;
+      type: string;
+      title: string;
+      date: string;
+      url: string;
+    }>
+  >(
+    (djData?.press || []).map((p: any) => ({
+      id: p.id || 0,
+      source: p.source || "",
+      type: p.type || "Feature",
+      title: p.title || "",
+      date: p.date || "",
+      url: p.url || "",
+    })),
+  );
   const bookCTARefMobile = useRef<BookCTARef>(null);
   const bookCTARefDesktop = useRef<BookCTARef>(null);
   const [venues, setVenues] = useState<
@@ -578,6 +605,89 @@ export default function DjProfilePremium({
     } catch (error) {
       console.error("Failed to save highlights:", error);
       toast.error("Failed to save highlights. Please try again.", {
+        id: toastId,
+      });
+    }
+  }
+
+  async function handlePressSave(newPressItems: typeof pressItems) {
+    const toastId = toast.loading("Saving press items...");
+
+    try {
+      // IDs > 1000000000000 are temporary Date.now() IDs (new items not yet saved)
+      const TEMP_ID_THRESHOLD = 1000000000000;
+      const itemsToAdd = newPressItems.filter((p) => p.id > TEMP_ID_THRESHOLD);
+      const itemsToUpdate = newPressItems.filter(
+        (p) => p.id > 0 && p.id <= TEMP_ID_THRESHOLD,
+      );
+      const removedItemIds = pressItems
+        .filter((p) => !newPressItems.find((np) => np.id === p.id))
+        .map((p) => p.id)
+        .filter((id) => id > 0 && id <= TEMP_ID_THRESHOLD); // Only delete real DB IDs
+
+      const addedItemIds: number[] = [];
+      for (const item of itemsToAdd) {
+        if (!item.source.trim() || !item.title.trim()) {
+          continue;
+        }
+        const formData = new FormData();
+        formData.append("source", item.source.trim());
+        formData.append("type", item.type.trim());
+        formData.append("title", item.title.trim());
+        if (item.date.trim()) formData.append("date", item.date.trim());
+        if (item.url.trim()) formData.append("url", item.url.trim());
+
+        const result = await createDjPressItem(formData);
+        if ("error" in result) {
+          toast.error(result.error, { id: toastId });
+          return;
+        }
+        if ("success" in result) {
+          addedItemIds.push(result.id);
+        }
+      }
+
+      for (const item of itemsToUpdate) {
+        if (!item.id || item.id === undefined || item.id === null) {
+          continue;
+        }
+        const formData = new FormData();
+        formData.append("source", item.source.trim());
+        formData.append("type", item.type.trim());
+        formData.append("title", item.title.trim());
+        formData.append("date", item.date.trim());
+        formData.append("url", item.url.trim());
+
+        const result = await updateDjPressItem(item.id, formData);
+        if ("error" in result) {
+          toast.error(result.error, { id: toastId });
+          return;
+        }
+      }
+
+      for (const itemId of removedItemIds) {
+        const result = await deleteDjPressItem(itemId);
+        if ("error" in result) {
+          toast.error(result.error, { id: toastId });
+          return;
+        }
+      }
+
+      toast.success("Press items saved successfully!", { id: toastId });
+
+      const updatedItems = newPressItems.map((p) => {
+        if (p.id > TEMP_ID_THRESHOLD && addedItemIds.length > 0) {
+          const newId = addedItemIds.shift();
+          return { ...p, id: newId || 0 };
+        }
+        return p;
+      });
+      setPressItems(updatedItems);
+
+      window.location.reload();
+    } catch (error) {
+      console.error("Failed to save press items:", error);
+      toast.error("Failed to save press items. Please try again.", {
         id: toastId,
       });
     }
@@ -986,23 +1096,33 @@ export default function DjProfilePremium({
               </>
             )}
 
-            {PRESS.length > 0 && (
+            {(PRESS.length > 0 || isOwner) && (
               <>
                 <Separator className="bg-white/8" />
 
                 {/* ── PRESS & MEDIA ── */}
-                <section>
-                  <SectionHeading sub="Interviews, features, and podcasts">
-                    Press &amp; Media
-                  </SectionHeading>
-                  <div className="grid gap-3 sm:grid-cols-2">
-                    {PRESS.map((p) => {
-                      const PressIcon = p.icon;
-                      return (
-                        <Card
-                          key={p.title}
-                          className="bg-h_blackLight/30 group cursor-pointer gap-0 border-white/8 p-4 transition-colors hover:border-white/15"
-                        >
+                <section id="press">
+                  <div className="mb-5 flex items-center justify-between">
+                    <SectionHeading sub="Interviews, features, and podcasts">
+                      Press &amp; Media
+                    </SectionHeading>
+                    {isOwner && PRESS.length > 0 && (
+                      <Button
+                        onClick={() => setIsPressModalOpen(true)}
+                        variant="ghost"
+                        size="sm"
+                        className="text-xs text-gray-400 hover:text-white"
+                      >
+                        <Pencil className="mr-1.5 h-3 w-3" />
+                        Edit
+                      </Button>
+                    )}
+                  </div>
+                  {PRESS.length > 0 ? (
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      {PRESS.map((p) => {
+                        const PressIcon = p.icon;
+                        const cardContent = (
                           <div className="flex items-start gap-3">
                             <div className="flex size-9 shrink-0 items-center justify-center rounded-md border border-white/8 bg-white/5">
                               <PressIcon className="h-3.5 w-3.5 text-gray-400 transition-colors group-hover:text-white" />
@@ -1024,10 +1144,37 @@ export default function DjProfilePremium({
                               </p>
                             </div>
                           </div>
-                        </Card>
-                      );
-                    })}
-                  </div>
+                        );
+                        return p.url ? (
+                          <a
+                            key={p.id}
+                            href={p.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            <Card className="bg-h_blackLight/30 group h-full cursor-pointer gap-0 border-white/8 p-4 transition-colors hover:border-white/15">
+                              {cardContent}
+                            </Card>
+                          </a>
+                        ) : (
+                          <Card
+                            key={p.id}
+                            className="bg-h_blackLight/30 group gap-0 border-white/8 p-4"
+                          >
+                            {cardContent}
+                          </Card>
+                        );
+                      })}
+                    </div>
+                  ) : (
+                    <EmptySectionState
+                      icon={Newspaper}
+                      title="No press items yet"
+                      description="Add interviews, features, and podcast appearances"
+                      actionLabel="Add Press"
+                      onAction={() => setIsPressModalOpen(true)}
+                    />
+                  )}
                 </section>
               </>
             )}
@@ -1274,6 +1421,13 @@ export default function DjProfilePremium({
             onClose={() => setIsHighlightModalOpen(false)}
             highlights={highlights}
             onSave={handleHighlightSave}
+          />
+          <PressModal
+            key={isPressModalOpen ? "press-modal-open" : "press-modal-closed"}
+            isOpen={isPressModalOpen}
+            onClose={() => setIsPressModalOpen(false)}
+            pressItems={pressItems}
+            onSave={handlePressSave}
           />
         </>
       )}

--- a/src/components/dj-profile/DjProfileSubNav.tsx
+++ b/src/components/dj-profile/DjProfileSubNav.tsx
@@ -12,6 +12,7 @@ const TABS: Tab[] = [
   { id: "about", label: "About" },
   { id: "events", label: "Events" },
   { id: "media", label: "Media" },
+  { id: "press", label: "Press" },
   { id: "packages", label: "Packages" },
 ];
 

--- a/src/components/dj-profile/PressModal.tsx
+++ b/src/components/dj-profile/PressModal.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { useState } from "react";
+import { X, Plus, Trash2, CalendarIcon } from "lucide-react";
+import { format, parse } from "date-fns";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Calendar } from "@/components/ui/calendar";
+import { cn } from "@/lib/utils";
+
+interface PressItem {
+  id: number;
+  source: string;
+  type: string;
+  title: string;
+  date: string;
+  url: string;
+}
+
+interface PressModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  pressItems: PressItem[];
+  onSave: (pressItems: PressItem[]) => void;
+}
+
+const PRESS_TYPES = ["Feature", "Interview", "Podcast", "Review", "Other"];
+
+export default function PressModal({
+  isOpen,
+  onClose,
+  pressItems: initialPressItems,
+  onSave,
+}: PressModalProps) {
+  const [pressItems, setPressItems] = useState<PressItem[]>(() =>
+    initialPressItems.length === 0
+      ? [
+          {
+            id: Date.now(),
+            source: "",
+            type: "Feature",
+            title: "",
+            date: "",
+            url: "",
+          },
+        ]
+      : initialPressItems,
+  );
+  const [openDateIndex, setOpenDateIndex] = useState<number | null>(null);
+
+  function parsePressDate(str: string): Date | undefined {
+    if (!str) return undefined;
+    const parsed = parse(str, "MMM yyyy", new Date());
+    return isNaN(parsed.getTime()) ? undefined : parsed;
+  }
+
+  function formatPressDate(date: Date | undefined): string {
+    if (!date) return "";
+    return format(date, "MMM yyyy");
+  }
+
+  function addPressItem() {
+    setPressItems((prev) => [
+      ...prev,
+      {
+        id: Date.now(),
+        source: "",
+        type: "Feature",
+        title: "",
+        date: "",
+        url: "",
+      },
+    ]);
+  }
+
+  function removePressItem(index: number) {
+    setPressItems((prev) => prev.filter((_, idx) => idx !== index));
+  }
+
+  function updatePressItem(index: number, field: string, value: any) {
+    setPressItems((prev) =>
+      prev.map((p, idx) => (idx === index ? { ...p, [field]: value } : p)),
+    );
+  }
+
+  function handleSave() {
+    const validItems = pressItems.filter(
+      (p) => p.source.trim() !== "" && p.title.trim() !== "",
+    );
+    onSave(validItems);
+    onClose();
+  }
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
+      <div className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-lg border border-white/10 bg-black p-6">
+        <div className="mb-6 flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-white">
+            Edit Press &amp; Media
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 transition-colors hover:text-white"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          {pressItems.map((item, index) => (
+            <div
+              key={item.id || index}
+              className="flex flex-col gap-3 rounded-lg border border-white/10 bg-white/5 p-4"
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-medium text-gray-400">
+                  Press Item #{index + 1}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => removePressItem(index)}
+                  className="text-gray-500 transition-colors hover:text-red-400"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div>
+                  <Label className="mb-1.5 block text-xs text-gray-300">
+                    Outlet / Source *
+                  </Label>
+                  <Input
+                    value={item.source}
+                    onChange={(e) =>
+                      updatePressItem(index, "source", e.target.value)
+                    }
+                    placeholder="e.g., Mixmag"
+                    className="focus:border-h_red/50 border-white/10 bg-white/5 text-white placeholder:text-gray-600"
+                  />
+                </div>
+                <div>
+                  <Label className="mb-1.5 block text-xs text-gray-300">
+                    Type
+                  </Label>
+                  <Select
+                    value={item.type}
+                    onValueChange={(val) => updatePressItem(index, "type", val)}
+                  >
+                    <SelectTrigger className="focus:border-h_red/50 w-full border-white/10 bg-white/5 text-white">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent className="border-white/10 bg-black">
+                      {PRESS_TYPES.map((t) => (
+                        <SelectItem key={t} value={t}>
+                          {t}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <div>
+                <Label className="mb-1.5 block text-xs text-gray-300">
+                  Title *
+                </Label>
+                <Input
+                  value={item.title}
+                  onChange={(e) =>
+                    updatePressItem(index, "title", e.target.value)
+                  }
+                  placeholder="e.g., The Sound of Lagos Goes Global"
+                  className="focus:border-h_red/50 border-white/10 bg-white/5 text-white placeholder:text-gray-600"
+                />
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div>
+                  <Label className="mb-1.5 block text-xs text-gray-300">
+                    Date (optional)
+                  </Label>
+                  <Popover
+                    open={openDateIndex === index}
+                    onOpenChange={(open) =>
+                      setOpenDateIndex(open ? index : null)
+                    }
+                  >
+                    <PopoverTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className={cn(
+                          "focus:border-h_red/50 h-9 w-full justify-start border-white/10 bg-white/5 text-left font-normal text-white",
+                          !item.date && "text-gray-600",
+                        )}
+                      >
+                        <CalendarIcon className="mr-1.5 h-3.5 w-3.5" />
+                        {item.date || "Pick a date"}
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent
+                      className="w-auto border-white/10 bg-black p-0"
+                      align="start"
+                    >
+                      <Calendar
+                        mode="single"
+                        selected={parsePressDate(item.date)}
+                        onSelect={(date) => {
+                          updatePressItem(index, "date", formatPressDate(date));
+                          setOpenDateIndex(null);
+                        }}
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </div>
+                <div>
+                  <Label className="mb-1.5 block text-xs text-gray-300">
+                    URL (optional)
+                  </Label>
+                  <Input
+                    type="url"
+                    value={item.url}
+                    onChange={(e) =>
+                      updatePressItem(index, "url", e.target.value)
+                    }
+                    placeholder="https://..."
+                    className="focus:border-h_red/50 border-white/10 bg-white/5 text-white placeholder:text-gray-600"
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+          <Button
+            type="button"
+            onClick={addPressItem}
+            variant="outline"
+            className="border-dashed border-white/20 bg-white/5 text-gray-400 hover:bg-white/10 hover:text-white"
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            {pressItems.length === 0 ? "Add Press Item" : "Add More"}
+          </Button>
+        </div>
+
+        <div className="mt-6 flex justify-end gap-3">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onClose}
+            className="text-gray-400 hover:text-white"
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSave}>
+            Save Press Items
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dj-profile/PressModal.tsx
+++ b/src/components/dj-profile/PressModal.tsx
@@ -115,6 +115,8 @@ export default function PressModal({
           </h2>
           <button
             onClick={onClose}
+            type="button"
+            aria-label="Close"
             className="text-gray-400 transition-colors hover:text-white"
           >
             <X className="h-5 w-5" />

--- a/src/data/dj-profile-defaults.ts
+++ b/src/data/dj-profile-defaults.ts
@@ -311,31 +311,39 @@ export const PREMIUM_DEFAULT_HIGHLIGHTS = [
 
 export const PREMIUM_DEFAULT_PRESS = [
   {
+    id: 1,
     outlet: "Mixmag",
     type: "Feature",
     title: "The Sound of Lagos Goes Global",
     date: "Mar 2025",
+    url: "",
     icon: Newspaper,
   },
   {
+    id: 2,
     outlet: "Resident Advisor",
     type: "Interview",
     title: "Amara Pulse: 'Music is My Language'",
     date: "Jan 2025",
+    url: "",
     icon: MicVocal,
   },
   {
+    id: 3,
     outlet: "BBC Music",
     type: "Podcast",
     title: "Africa Dancefloor Series Ep.12",
     date: "Nov 2024",
+    url: "",
     icon: Headphones,
   },
   {
+    id: 4,
     outlet: "Fact Magazine",
     type: "Interview",
     title: "Breaking Borders Through Afrobeats",
     date: "Sep 2024",
+    url: "",
     icon: Newspaper,
   },
 ];

--- a/src/lib/dj-profile-mappers.ts
+++ b/src/lib/dj-profile-mappers.ts
@@ -206,10 +206,12 @@ export function mapHighlightsFromData(d: DjDemoData) {
 
 export function mapPressFromData(d: DjDemoData) {
   return d.press.map((p) => ({
+    id: p.id,
     outlet: p.source,
     type: p.type,
     title: p.title,
     date: p.date,
+    url: p.url || "",
     icon: PRESS_ICON_MAP[p.type] ?? Newspaper,
   }));
 }

--- a/src/types/dj-demo.ts
+++ b/src/types/dj-demo.ts
@@ -122,10 +122,12 @@ export interface DjDemoData {
     quote: string;
   }>;
   press: Array<{
+    id: number;
     source: string;
     type: string;
     title: string;
     date: string;
+    url?: string;
   }>;
   venuesPlayed?: Array<{
     id: number;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Press & Media section to DJ profiles with navigation support.
  * DJ profile owners can add, edit, delete, and reorder press items.
  * Press entries support source, type, title, date, and optional external links.
  * Added validation and clear empty-state messaging for profiles without press items.
  * Press cards can now link directly to external coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->